### PR TITLE
Enable column-search for a few columns in the puzzles table.

### DIFF
--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -8,7 +8,7 @@
             <th scope="col">Status</th>
             <th scope="col">Sheet</th>
             <th scope="col">Slack</th>
-	    <th scope="col">Tags</th>
+            <th scope="col">Tags</th>
             <th scope="col"></th>
             <th scope="col"></th>
         </tr>
@@ -76,21 +76,56 @@
             </tr>
             {% endfor %}
     </tbody>
+    <tfoot>
+        <tr>
+            <th scope="col" class="column_searchable">Puzzle</th>
+            <th scope="col" class="column_searchable">Answer</th>
+            <th scope="col" class="column_searchable">Status</th>
+            <th scope="col">Sheet</th>
+            <th scope="col">Slack</th>
+            <th scope="col" class="column_searchable">Tags</th>
+            <th scope="col"></th>
+            <th scope="col"></th>
+        </tr>
+    </tfoot>
 </table>
 
 <script type="text/javascript">
 $(document).ready(function() {
+    // For choice fields, each entry should only be searchable by the currently
+    // selected value.
     $.fn.dataTableExt.ofnSearch['select-input'] = function(value) {
         return $(value).find('select').val();
     };
 
-    $('#puzzles').DataTable( {
+    // TODO(asdfryan): Also fix search for checklist input (i.e. meta column).
+
+    // Add a text input for each footer cell that is column_searchable.
+    $('#puzzles .column_searchable').each( function () {
+        var col_name = $(this).text();
+        $(this).html( '<input type="text" placeholder="Search '+col_name+'" />' );
+    } );
+
+
+    var table = $('#puzzles').DataTable( {
         "paging": false,
         "info": false,
         "columnDefs": [
             { "orderable": false, "targets": [2, 3, 4, 5, 6] },
             { "type": "select-input", "targets": [2] }
         ]
+    } );
+
+    // Apply column search.
+    table.columns().every( function () {
+        var that = this;
+        $( 'input', this.footer() ).on( 'keyup change clear', function () {
+            if ( that.search() !== this.value ) {
+                that
+                    .search( this.value )
+                    .draw();
+            }
+        } );
     } );
 });
 


### PR DESCRIPTION
Tested locally -- see screenshots below.

Original page:
![screenshot1](https://user-images.githubusercontent.com/1498449/70029828-c8e75600-155c-11ea-9e0d-2c19ea8c82bb.png)

Basic column filter works:
![screenshot2](https://user-images.githubusercontent.com/1498449/70029870-e0beda00-155c-11ea-9e20-ef78b9b63fbe.png)

It filters on the right column:
![screenshot3](https://user-images.githubusercontent.com/1498449/70029949-021fc600-155d-11ea-85a6-2668b8b2f42a.png)

Combinations of filters also work:
![screenshot4](https://user-images.githubusercontent.com/1498449/70029990-1794f000-155d-11ea-8fb6-9ea1c042ba0e.png)
