### PR TITLE
Support search / column filtering in Answer Queue

### DIFF
--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -46,18 +46,58 @@
             </tr>
             {% endfor %}
     </tbody>
+    <tfoot>
+        <tr>
+            <th scope="col">Time</th>
+            <th scope="col" class="column_searchable">Puzzle</th>
+            <th scope="col" class="column_searchable">Answer</th>
+            <th scope="col" class="column_searchable">Status</th>
+            <th scope="col" class="column_searchable">Notes (e.g. for Partials)</th>
+        </tr>
+    </tfoot>
 </table>
 
 <script type="text/javascript">
 $(document).ready(function() {
-    $('#queue').DataTable( {
+    // For choice fields, each entry should only be searchable by the currently
+    // selected value.
+    $.fn.dataTableExt.ofnSearch['select-input'] = function(value) {
+        return $(value).find('select').val();
+    };
+
+    // For text fields, enable search based on the initial value of the field
+    // when the table was loaded.
+    $.fn.dataTableExt.ofnSearch['text-input'] = function(value) {
+        return $(value).find(':text').val();
+    };
+
+    // Add a text input for each footer cell that is column_searchable.
+    $('#queue .column_searchable').each( function () {
+        var col_name = $(this).text();
+        $(this).html( '<input type="text" placeholder="Search '+col_name+'" />' );
+    } );
+
+    var table = $('#queue').DataTable( {
         "paging": true,
         "info": true,
         "columnDefs": [
             { "targets": [0], "type": "date" },
-            { "orderable": false, "targets": [3] }
+            { "type": "select-input", "orderable": false, "targets": [3] },
+            { "type": "text-input", "orderable": false, "targets": [4] }
         ],
         "order": [[ 0, "desc" ]]
+    } );
+
+    // Apply column search.
+    table.columns().every( function () {
+        var that = this;
+        $( 'input', this.footer() ).on( 'keyup change clear', function () {
+            if ( that.search() !== this.value ) {
+                that
+                    .search( this.value )
+                    .draw();
+            }
+        } );
     } );
 });
 </script>

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -8,7 +8,7 @@
             <th scope="col">Status</th>
             <th scope="col">Sheet</th>
             <th scope="col">Slack</th>
-	    <th scope="col">Tags</th>
+            <th scope="col">Tags</th>
             <th scope="col"></th>
             <th scope="col"></th>
         </tr>
@@ -76,21 +76,56 @@
             </tr>
             {% endfor %}
     </tbody>
+    <tfoot>
+        <tr>
+            <th scope="col" class="column_searchable">Puzzle</th>
+            <th scope="col" class="column_searchable">Answer</th>
+            <th scope="col" class="column_searchable">Status</th>
+            <th scope="col">Sheet</th>
+            <th scope="col">Slack</th>
+            <th scope="col" class="column_searchable">Tags</th>
+            <th scope="col"></th>
+            <th scope="col"></th>
+        </tr>
+    </tfoot>
 </table>
 
 <script type="text/javascript">
 $(document).ready(function() {
+    // For choice fields, each entry should only be searchable by the currently
+    // selected value.
     $.fn.dataTableExt.ofnSearch['select-input'] = function(value) {
         return $(value).find('select').val();
     };
 
-    $('#puzzles').DataTable( {
+    // TODO(asdfryan): Also fix search for checklist input (i.e. meta column).
+
+    // Add a text input for each footer cell that is column_searchable.
+    $('#puzzles .column_searchable').each( function () {
+        var col_name = $(this).text();
+        $(this).html( '<input type="text" placeholder="Search '+col_name+'" />' );
+    } );
+
+
+    var table = $('#puzzles').DataTable( {
         "paging": false,
         "info": false,
         "columnDefs": [
             { "orderable": false, "targets": [2, 3, 4, 5, 6] },
             { "type": "select-input", "targets": [2] }
         ]
+    } );
+
+    // Apply column search.
+    table.columns().every( function () {
+        var that = this;
+        $( 'input', this.footer() ).on( 'keyup change clear', function () {
+            if ( that.search() !== this.value ) {
+                that
+                    .search( this.value )
+                    .draw();
+            }
+        } );
     } );
 });
 

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -8,7 +8,7 @@
             <th scope="col">Status</th>
             <th scope="col">Sheet</th>
             <th scope="col">Slack</th>
-            <th scope="col">Tags</th>
+	    <th scope="col">Tags</th>
             <th scope="col"></th>
             <th scope="col"></th>
         </tr>
@@ -76,56 +76,21 @@
             </tr>
             {% endfor %}
     </tbody>
-    <tfoot>
-        <tr>
-            <th scope="col" class="column_searchable">Puzzle</th>
-            <th scope="col" class="column_searchable">Answer</th>
-            <th scope="col" class="column_searchable">Status</th>
-            <th scope="col">Sheet</th>
-            <th scope="col">Slack</th>
-            <th scope="col" class="column_searchable">Tags</th>
-            <th scope="col"></th>
-            <th scope="col"></th>
-        </tr>
-    </tfoot>
 </table>
 
 <script type="text/javascript">
 $(document).ready(function() {
-    // For choice fields, each entry should only be searchable by the currently
-    // selected value.
     $.fn.dataTableExt.ofnSearch['select-input'] = function(value) {
         return $(value).find('select').val();
     };
 
-    // TODO(asdfryan): Also fix search for checklist input (i.e. meta column).
-
-    // Add a text input for each footer cell that is column_searchable.
-    $('#puzzles .column_searchable').each( function () {
-        var col_name = $(this).text();
-        $(this).html( '<input type="text" placeholder="Search '+col_name+'" />' );
-    } );
-
-
-    var table = $('#puzzles').DataTable( {
+    $('#puzzles').DataTable( {
         "paging": false,
         "info": false,
         "columnDefs": [
             { "orderable": false, "targets": [2, 3, 4, 5, 6] },
             { "type": "select-input", "targets": [2] }
         ]
-    } );
-
-    // Apply column search.
-    table.columns().every( function () {
-        var that = this;
-        $( 'input', this.footer() ).on( 'keyup change clear', function () {
-            if ( that.search() !== this.value ) {
-                that
-                    .search( this.value )
-                    .draw();
-            }
-        } );
     } );
 });
 


### PR DESCRIPTION
Add same search functionality in Answer queue view, with added text-input search enabled for the Notes field. Previously this just didn't work at all.

![screenshot6](https://user-images.githubusercontent.com/1498449/70033159-b886a980-1563-11ea-98f5-27b6ffd989ba.png)

![screenshot5](https://user-images.githubusercontent.com/1498449/70033132-ad337e00-1563-11ea-80bf-e05a000be92b.png)

![screenshot7](https://user-images.githubusercontent.com/1498449/70033236-e53ac100-1563-11ea-9b04-9ecb7d126574.png)
