### PR TITLE
Restrict puzzle status update

### DIFF
--- a/puzzles/forms.py
+++ b/puzzles/forms.py
@@ -24,7 +24,7 @@ class StatusForm(forms.ModelForm):
         fields = ["status"]
 
     status = forms.ChoiceField(
-        choices=[(status, status) for status in Puzzle.STATUS_CHOICES],
+        choices=[(status, status) for status in Puzzle.ALL_STATUSES],
         widget=forms.Select(attrs={"onChange":'this.form.submit();', 'class': 'form-control form-control-sm'}))
 
 

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -16,7 +16,7 @@ class Puzzle(models.Model):
     STUCK = 'STUCK'
     EXTRACTION = 'EXTRACTION'
     ALL_STATUSES = [SOLVING, PENDING, SOLVED, STUCK, EXTRACTION]
-    # Users should only be able to change status to one of these 2.
+    # Users should only be able to change status to one of these 3.
     VISIBLE_STATUS_CHOICES = [SOLVING, STUCK, EXTRACTION]
 
     status = models.CharField(

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -14,11 +14,14 @@ class Puzzle(models.Model):
     PENDING = 'PENDING'
     SOLVED = 'SOLVED'
     STUCK = 'STUCK'
-    STATUS_CHOICES = [SOLVING, PENDING, SOLVED, STUCK]
+    EXTRACTION = 'EXTRACTION'
+    ALL_STATUSES = [SOLVING, PENDING, SOLVED, STUCK, EXTRACTION]
+    # Users should only be able to change status to one of these 2.
+    VISIBLE_STATUS_CHOICES = [SOLVING, STUCK, EXTRACTION]
 
     status = models.CharField(
         max_length=10,
-        choices=[(status, status) for status in STATUS_CHOICES],
+        choices=[(status, status) for status in ALL_STATUSES],
         default=SOLVING)
     answer = models.CharField(max_length=128)
 

--- a/puzzles/templatetags/puzzle_extras.py
+++ b/puzzles/templatetags/puzzle_extras.py
@@ -11,6 +11,9 @@ def get_table(puzzles, request):
     for (i, p) in enumerate(puzzles):
         if p.status in [Puzzle.SOLVED, Puzzle.PENDING]:
             status_forms[i].fields["status"].disabled = True
+        else:
+            status_forms[i].fields["status"].choices =\
+                [(status, status) for status in Puzzle.VISIBLE_STATUS_CHOICES]
 
     meta_forms = [MetaPuzzleForm(initial={'meta_select': p.metas.all()}) for p in puzzles]
 


### PR DESCRIPTION
Restrict UI to only allow changing to SOLVING, STUCK, or EXTRACTION. PENDING/SOLVED should be handled by the answer queue.