### PR TITLE
Remove circular import

### DIFF
--- a/answers/views.py
+++ b/answers/views.py
@@ -1,14 +1,15 @@
-from django.shortcuts import render, get_object_or_404
-from django.contrib.auth.decorators import login_required
-from django.contrib import messages
-from django.core.exceptions import ObjectDoesNotExist
-from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseRedirect
-from django.views import View
-from .models import Answer
 from .forms import UpdateAnswerNotesForm
 from .forms import UpdateAnswerStatusForm
+from .models import Answer
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseRedirect
+from django.shortcuts import render, get_object_or_404
+from django.views import View
 from hunts.models import Hunt
+from slack_lib.slack_client import SlackClient
 
 
 @login_required(login_url='/accounts/login/')
@@ -18,6 +19,11 @@ def update_note(request, answer_pk):
         answer = get_object_or_404(Answer, pk=answer_pk)
         notes_text = notes_form.cleaned_data["text"]
         answer.set_notes(notes_text)
+        slack_client = SlackClient.getInstance()
+        puzzle_channel = answer.puzzle.channel
+        slack_client.send_message(puzzle_channel,
+                                  "The operator has added an update regarding the answer "
+                                   "\'%s\'. Note: \'%s\'" % (answer.text.upper(), notes_text))
     return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
 
 
@@ -37,6 +43,24 @@ class AnswerView(LoginRequiredMixin, View):
             'rows' : zip(answers, forms, notes_forms)
         }
         return render(request, 'queue.html', context)
+    
+    @staticmethod
+    def __update_slack_with_puzzle_status(answer, status):
+        slack_client = SlackClient.getInstance()
+        puzzle_channel = answer.puzzle.channel
+        if status == Answer.PARTIAL:
+            slack_client.send_message(puzzle_channel,
+                                      "%s is PARTIALLY CORRECT!" %
+                                      answer.text.upper())
+        elif status == Answer.INCORRECT or status == Answer.CORRECT:
+            slack_client.send_message(puzzle_channel, "%s is %s!" %
+                                                      (answer.text.upper(), status))
+
+        if status == Answer.CORRECT:
+            slack_client.announce("%s has been solved with the answer: "
+                                   "\'%s\' Hurray!" %
+                                  (answer.puzzle.name, answer.text.upper()))
+
 
     def post(self, request, hunk_pk, answer_pk):
         status_form = UpdateAnswerStatusForm(request.POST)
@@ -50,6 +74,7 @@ class AnswerView(LoginRequiredMixin, View):
                     'We won\'t stop ya, but please think twice.')
 
             guess.set_status(status)
+            self.__update_slack_with_puzzle_status(guess, status)
 
         return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
 


### PR DESCRIPTION
puzzles/models.py imported answers/models.py which in turn imported slack_client.py. 

I thought about this briefly, and think the right thing to do is to disallow any models from calling slack_client.py (because slack_client itself relies on the Puzzle model). Not sure if this is the best thing to do.