### PR TITLE
metas field should be asymmetrical

### DIFF
--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -29,7 +29,7 @@ class Puzzle(models.Model):
 
     tags = TaggableManager()
 
-    metas = models.ManyToManyField('self') 
+    metas = models.ManyToManyField('self', symmetrical=False) 
 
     is_meta = models.BooleanField(default=False)
 


### PR DESCRIPTION
If puzzle A is a meta of B, B is not necessarily meta of A (in fact it shouldn't be).