### PR TITLE
Fix 500 error due to meta_select KeyError

### DIFF
--- a/puzzles/templatetags/puzzle_extras.py
+++ b/puzzles/templatetags/puzzle_extras.py
@@ -15,7 +15,7 @@ def get_table(puzzles, request):
             status_forms[i].fields["status"].choices =\
                 [(status, status) for status in Puzzle.VISIBLE_STATUS_CHOICES]
 
-    meta_forms = [MetaPuzzleForm(initial={'meta_select': p.metas.all()}, instance=p) for p in puzzles]
+    meta_forms = [MetaPuzzleForm(initial={'metas': p.metas.all()}, instance=p) for p in puzzles]
 
     context = {
         'rows': zip(puzzles, status_forms, meta_forms),

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -80,7 +80,7 @@ def set_metas(request, pk):
         form = MetaPuzzleForm(request.POST, instance=get_object_or_404(Puzzle, pk=pk))
         if form.is_valid():
             puzzle = get_object_or_404(Puzzle, pk=pk)
-            metas = form.cleaned_data["meta_select"]
+            metas = form.cleaned_data["metas"]
             puzzle.metas.set(metas)
 
     return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))


### PR DESCRIPTION
This was the error I got with the latest code: http://dpaste.com/0Y2QCQC

```
Traceback:

File "/mnt/c/Users/volde/Desktop/github/cardinalitypuzzles/smallboard/venv/lib/python3.7/site-packages/django/core/handlers/exception.py" in inner
  34.             response = get_response(request)

File "/mnt/c/Users/volde/Desktop/github/cardinalitypuzzles/smallboard/venv/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  115.                 response = self.process_exception_by_middleware(e, request)

File "/mnt/c/Users/volde/Desktop/github/cardinalitypuzzles/smallboard/venv/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  113.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/mnt/c/Users/volde/Desktop/github/cardinalitypuzzles/smallboard/venv/lib/python3.7/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
  21.                 return view_func(request, *args, **kwargs)

File "/mnt/c/Users/volde/Desktop/github/cardinalitypuzzles/smallboard/puzzles/views.py" in set_metas
  83.             metas = form.cleaned_data["meta_select"]

Exception Type: KeyError at /puzzles/meta/5/
Exception Value: 'meta_select'
```

`metas_select` was renamed to `metas` in some recent changes; updating the field name elsewhere to fix the 500 error that happens when assigning a puzzle to a meta.