### PR TITLE
Add edit functionality for puzzle name, url, and meta status

### DIFF
--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -77,6 +77,8 @@ class Puzzle(models.Model):
 
         # If previously a metapuzzle, but no longer one.
         if self.is_meta and not new_is_meta:
+            # TODO(asdfryan): Consider auto-deleting the relevant meta
+            # assignments instead of raising error.
             if (Puzzle.objects.filter(metas__id=self.pk)):
                 raise InvalidMetaPuzzleError(
                     "Metapuzzles can only be deleted or made non-meta if no "

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -1,5 +1,7 @@
 {% load puzzle_extras %}
 
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+
 <table class="table table-sm" id="puzzles">
     <thead>
         <tr>
@@ -14,10 +16,42 @@
         </tr>
     </thead>
     <tbody>
-            {% for p, status_form, meta_form in rows %}
+            {% for p, status_form, meta_form, edit_form in rows %}
             <tr class="{% puzzle_class p %}">
                 <th scope="row">
                     {% get_title p %}
+                    <i class="fa fa-edit" data-toggle="modal" data-target="#editpuzzle-{{ p.pk }}"></i>
+                    <div class="modal fade" id="editpuzzle-{{ p.pk }}" tabindex="-1" role="dialog" aria-labelledby="edittitle-{{ p.pk }}" aria-hidden="true">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="edittitle-{{ p.pk }}">Edit Puzzle</h5>
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                                <form method="post" action="/puzzles/edit/{{ p.pk }}/">
+                                    {% csrf_token %}
+                                    <div class="modal-body">
+                                        <div class="form-group">
+                                            {{ edit_form.name }}
+                                        </div>
+                                        <div class="form-group">
+                                            {{ edit_form.url }}
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-check-label" for="id_is_meta">Meta?</label>
+                                            {{ edit_form.is_meta }}
+                                        </div>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                                        <button type="submit" class="btn btn-primary">Submit</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
                 </th>
                 <td><p class="text-monospace">{{ p.answer.upper }}</p></td>
                 <td>

--- a/puzzles/templatetags/puzzle_extras.py
+++ b/puzzles/templatetags/puzzle_extras.py
@@ -1,6 +1,6 @@
 from django import template
 from puzzles.models import Puzzle
-from puzzles.forms import StatusForm, MetaPuzzleForm
+from puzzles.forms import StatusForm, MetaPuzzleForm, PuzzleForm
 from answers.forms import AnswerForm
 
 register = template.Library()
@@ -17,8 +17,10 @@ def get_table(puzzles, request):
 
     meta_forms = [MetaPuzzleForm(initial={'metas': p.metas.all()}, instance=p) for p in puzzles]
 
+    edit_forms = [PuzzleForm(initial={'name': p.name, 'url': p.url, 'is_meta': p.is_meta}) for p in puzzles]
+
     context = {
-        'rows': zip(puzzles, status_forms, meta_forms),
+        'rows': zip(puzzles, status_forms, meta_forms, edit_forms),
         'guess_form': AnswerForm(),
     }
     return context

--- a/puzzles/urls.py
+++ b/puzzles/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("guess/<int:pk>/", views.guess, name="guess"),
     path("slack_guess/", views.slack_guess, name="slack_guess"),
     path("meta/<int:pk>/", views.set_metas),
+    path("edit/<int:pk>/", views.edit_puzzle),
 ]

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -97,6 +97,8 @@ def edit_puzzle(request, pk):
             puzzle = get_object_or_404(Puzzle, pk=pk)
             try:
                 puzzle.update_metadata(new_name, new_url, new_is_meta)
+                # TODO(asdfryan): Consider also renaming the slack channel to match the
+                # new puzzle name.
             except (DuplicatePuzzleNameError, DuplicatePuzzleUrlError, InvalidMetaPuzzleError) as e:
                messages.error(request, str(e))
 

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -7,9 +7,10 @@ from django.http import HttpResponse
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
+from url_normalize import url_normalize
 
-from .models import Puzzle
-from .forms import StatusForm, MetaPuzzleForm
+from .models import *
+from .forms import StatusForm, MetaPuzzleForm, PuzzleForm
 from answers.models import Answer
 from answers.forms import AnswerForm
 
@@ -84,3 +85,20 @@ def set_metas(request, pk):
             puzzle.metas.set(metas)
 
     return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+
+@login_required(login_url='/accounts/login/')
+def edit_puzzle(request, pk):
+    if request.method == 'POST':
+        form = PuzzleForm(request.POST)
+        if form.is_valid():
+            new_name = form.cleaned_data["name"]
+            new_url = url_normalize(form.cleaned_data["url"])
+            new_is_meta = form.cleaned_data["is_meta"]
+            puzzle = get_object_or_404(Puzzle, pk=pk)
+            try:
+                puzzle.update_metadata(new_name, new_url, new_is_meta)
+            except (DuplicatePuzzleNameError, DuplicatePuzzleUrlError, InvalidMetaPuzzleError) as e:
+               messages.error(request, str(e))
+
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+


### PR DESCRIPTION
You can use it by clicking on the pencil icons.
![screencapture-127-0-0-1-8000-hunts-1-2019-12-08-17_13_15](https://user-images.githubusercontent.com/1498449/70400147-1f7de580-19de-11ea-99d2-e12ac7d27411.png)

It opens up a popup that's essentially the same as the New Puzzle form, but fields defaulted to the current model's fields.
![screencapture-127-0-0-1-8000-hunts-1-2019-12-08-17_14_13](https://user-images.githubusercontent.com/1498449/70400156-2c9ad480-19de-11ea-8133-3eb9f4ea0fb6.png)

Validation on dup puzzle names/urls, and invalid meta state.
![screencapture-127-0-0-1-8000-hunts-1-2019-12-08-17_16_17](https://user-images.githubusercontent.com/1498449/70400193-77b4e780-19de-11ea-8001-8e5061ccb5fd.png)

![screencapture-127-0-0-1-8000-hunts-1-2019-12-08-17_15_43](https://user-images.githubusercontent.com/1498449/70400184-623fbd80-19de-11ea-8189-734b84753e01.png)
