### PR TITLE
Use JavaScript to fetch tags modal (#84)

### DIFF
--- a/puzzles/tag_utils.py
+++ b/puzzles/tag_utils.py
@@ -1,0 +1,31 @@
+from .models import Puzzle
+from .puzzle_tag import PuzzleTag
+
+DEFAULT_TAGS = [
+    ('HIGH PRIORITY', PuzzleTag.RED),
+    ('LOW PRIORITY', PuzzleTag.YELLOW),
+    ('BACKSOLVED', PuzzleTag.GREEN),
+    ('WORD', PuzzleTag.WHITE),
+    ('LOGIC', PuzzleTag.WHITE),
+    ('TECHNICAL', PuzzleTag.WHITE),
+    ('SLOG', PuzzleTag.GRAY),
+]
+
+
+def to_tag(tag_string):
+    # Override default taggit behavior of splitting input string.
+    return [tag_string.upper()]
+
+
+def get_tags(puzzle):
+    puzzle_tags = [(t.name, t.color) for t in puzzle.tags.all()]
+    puzzle_tags.sort(key=lambda item: (PuzzleTag.COLOR_ORDERING[item[1]], item[0]))
+    return puzzle_tags
+
+
+def get_all_tags():
+    all_tags = dict(
+        DEFAULT_TAGS +
+        [(t.name, t.color) for t in Puzzle.tags.all()]
+    )
+    return all_tags

--- a/puzzles/templates/modals/add_tag.html
+++ b/puzzles/templates/modals/add_tag.html
@@ -1,0 +1,22 @@
+<div class="modal fade" id="addtag" tabindex="-1" role="dialog" aria-labelledby="addtag" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+$(function () {
+  $(".addtag").click(function() {
+    var pk = $(this).data("pk");
+    $.get({
+        "url": `/puzzles/add_tags_form/${pk}`,
+        'csrfmiddlewaretoken': '{{ csrf_token }}'
+	}).done(function(data) {
+        console.log(pk)
+        $("#addtag .modal-content").html(data);
+    })
+  })
+});
+</script>

--- a/puzzles/templates/modals/add_tag.html
+++ b/puzzles/templates/modals/add_tag.html
@@ -11,8 +11,7 @@ $(function () {
   $(".addtag").click(function() {
     var pk = $(this).data("pk");
     $.get({
-        "url": `/puzzles/add_tags_form/${pk}`,
-        'csrfmiddlewaretoken': '{{ csrf_token }}'
+        "url": `/puzzles/add_tags_form/${pk}`
 	}).done(function(data) {
         $("#addtag .modal-content").html(data);
     })

--- a/puzzles/templates/modals/add_tag.html
+++ b/puzzles/templates/modals/add_tag.html
@@ -14,7 +14,6 @@ $(function () {
         "url": `/puzzles/add_tags_form/${pk}`,
         'csrfmiddlewaretoken': '{{ csrf_token }}'
 	}).done(function(data) {
-        console.log(pk)
         $("#addtag .modal-content").html(data);
     })
   })

--- a/puzzles/templates/modals/tags_form.html
+++ b/puzzles/templates/modals/tags_form.html
@@ -1,0 +1,34 @@
+            <div class="modal-header">
+                <h5 class="modal-title" id="addtag-title">Add tag to {{puzzle.name}}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                {% for tag, class in suggestions %}
+                    <form  style="display: inline;" method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/">
+                        {% csrf_token %}
+                        <input type="hidden" name="name" value="{{ tag }}">
+                        <input type="hidden" name="color" value="{{ class }}">
+                        <button type="submit" class="btn btn-{{class}} btn-sm"> {{ tag }} </button>
+                    </form>
+                {% endfor %}
+                <br>
+                <br>
+                <button type="button" class="btn btn-info btn-sm btn-block" data-toggle="collapse" data-target="#collapseTagInput" aria-expanded="false" aria-controls="collapseTagInput"> <i class="fa fa fa-plus" aria-hidden="true"></i> Add New Tag </button>
+                <div class="collapse" id="collapseTagInput">
+                  <div class="card card-body">
+                    <form method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/">
+                        {% csrf_token %}
+                        <div class="form-group">
+                            {{ tag_form.name }}
+                            {{ tag_form.color }}
+                         <button type="submit" class="btn btn-primary btn-sm">add</button>
+                        </div>
+                    </form>
+                  </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+            </div>

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -34,7 +34,7 @@
             <td><a href="{{ p.sheet }}">Link</a></td>
             <td><a href="{{ slack_base_url }}/app_redirect?channel={{ p.channel }}">Link</a></td>
             <td>
-                {% show_tags p request %}
+                {% show_tags p %}
             </td>
             <td>
                 {% if p.status != "SOLVED" %}

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -1,4 +1,5 @@
 {% load puzzle_extras %}
+{% include "modals/add_tag.html" %}
 {% include "modals/set_meta.html" %}
 
 
@@ -16,7 +17,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for p, status_form, edit_form, tag_form, puzzle_class in rows %}
+        {% for p, status_form, edit_form, puzzle_class in rows %}
         <tr class="{{ puzzle_class }}">
             <td scope="row">
                 {% get_title p edit_form %}
@@ -33,7 +34,7 @@
             <td><a href="{{ p.sheet }}">Link</a></td>
             <td><a href="{{ slack_base_url }}/app_redirect?channel={{ p.channel }}">Link</a></td>
             <td>
-                {% show_tags p tag_form request %}
+                {% show_tags p request %}
             </td>
             <td>
                 {% if p.status != "SOLVED" %}

--- a/puzzles/templates/show_tags.html
+++ b/puzzles/templates/show_tags.html
@@ -10,49 +10,6 @@
     </form>
 {% endfor %}
 
-<button type="button" class="btn btn-default" data-toggle="modal" data-target="#addtag-{{ puzzle.pk }}" style="padding: 0px 0px;">
+<button type="button" class="addtag btn btn-default" data-toggle="modal" data-target="#addtag" data-pk="{{ puzzle.pk }}" style="padding: 0px 0px;">
     <i class="fa fa-xs fa-plus" aria-hidden="true"></i>
 </button>
-
-<div class="modal fade" id="addtag-{{ puzzle.pk }}" tabindex="-1" role="dialog" aria-labelledby="addtag-{{ puzzle.pk }}" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="addtag-{{ puzzle.pk }}">Add tag to {{puzzle.name}}</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                {% for tag, class in suggestions %}
-                    <form  style="display: inline;" method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/">
-                        {% csrf_token %}
-                        <input type="hidden" name="name" value="{{ tag }}">
-                        <input type="hidden" name="color" value="{{ class }}">
-                        <button type="submit" class="btn btn-{{class}} btn-sm"> {{ tag }} </button>
-                    </form>
-                {% endfor %}
-
-                <br>
-                <br>
-
-                <button type="button" class="btn btn-info btn-sm btn-block" data-toggle="collapse" data-target="#collapseTagInput" aria-expanded="false" aria-controls="collapseTagInput"> <i class="fa fa fa-plus" aria-hidden="true"></i> Add New Tag </button>
-                <div class="collapse" id="collapseTagInput">
-                  <div class="card card-body">
-                    <form method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/">
-                        {% csrf_token %}
-                        <div class="form-group">
-                            {{ tag_form.name }}
-                            {{ tag_form.color }}
-                         <button type="submit" class="btn btn-primary btn-sm">add</button>
-                        </div>
-                    </form>
-                  </div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-            </div>
-        </div>
-    </div>
-</div>

--- a/puzzles/templatetags/puzzle_extras.py
+++ b/puzzles/templatetags/puzzle_extras.py
@@ -2,21 +2,13 @@ import cgi
 from django import template
 from django.conf import settings
 from django.template.defaultfilters import stringfilter
+from puzzles import tag_utils
 from puzzles.models import Puzzle
-from puzzles.puzzle_tag import PuzzleTag
 from puzzles.puzzle_tree import *
 from puzzles.forms import StatusForm, MetaPuzzleForm, PuzzleForm, TagForm
 from answers.forms import AnswerForm
 
-DEFAULT_TAGS = [
-    ('HIGH PRIORITY', PuzzleTag.RED),
-    ('LOW PRIORITY', PuzzleTag.YELLOW),
-    ('BACKSOLVED', PuzzleTag.GREEN),
-    ('WORD', PuzzleTag.WHITE),
-    ('LOGIC', PuzzleTag.WHITE),
-    ('TECHNICAL', PuzzleTag.WHITE),
-    ('SLOG', PuzzleTag.GRAY),
-]
+
 
 register = template.Library()
 
@@ -100,27 +92,14 @@ def assign_metas(puzzle, meta_form):
     return context
 
 
-def create_tag_context(puzzle):
-    all_tags = dict(
-        DEFAULT_TAGS +
-        [(t.name, t.color) for t in Puzzle.tags.all()]
-    )
-    current_tags = [(t.name, t.color) for t in puzzle.tags.all()]
-    current_tags.sort(key=lambda item: (PuzzleTag.COLOR_ORDERING[item[1]], item[0]))
-    suggestions = [t for t in all_tags.items() if t not in current_tags]
-    suggestions.sort(key=lambda item: (PuzzleTag.COLOR_ORDERING[item[1]], item[0]))
-
+@register.inclusion_tag('show_tags.html')
+def show_tags(puzzle):
+    puzzle_tags = tag_utils.get_tags(puzzle)
     context = {
         'puzzle': puzzle,
-        'current_tags': current_tags,
-        'tag_form': TagForm(),
-        'suggestions': suggestions
+        'current_tags': puzzle_tags,
     }
     return context
-
-@register.inclusion_tag('show_tags.html')
-def show_tags(puzzle, request):
-    return create_tag_context(puzzle)
 
 
 @register.filter(name='escape')

--- a/puzzles/templatetags/puzzle_extras.py
+++ b/puzzles/templatetags/puzzle_extras.py
@@ -49,7 +49,6 @@ def get_table(puzzles, request):
 
     # this caches Puzzle.tags.all() for all the tag forms
     Puzzle.objects.all().prefetch_related('tags')
-    tag_forms = [TagForm() for p in sorted_puzzles]
 
     def __get_puzzle_class(sorted_np_pairs):
         puzzle_class = [table_status_class(pair.node.puzzle) for pair in sorted_np_pairs]
@@ -73,7 +72,7 @@ def get_table(puzzles, request):
     puzzle_class = __get_puzzle_class(sorted_np_pairs)
 
     context = {
-        'rows': zip(sorted_puzzles, status_forms, edit_forms, tag_forms, puzzle_class),
+        'rows': zip(sorted_puzzles, status_forms, edit_forms, puzzle_class),
         'guess_form': AnswerForm(),
         'slack_base_url': settings.SLACK_BASE_URL,
     }
@@ -101,8 +100,7 @@ def assign_metas(puzzle, meta_form):
     return context
 
 
-@register.inclusion_tag('show_tags.html')
-def show_tags(puzzle, tag_form, request):
+def create_tag_context(puzzle):
     all_tags = dict(
         DEFAULT_TAGS +
         [(t.name, t.color) for t in Puzzle.tags.all()]
@@ -115,10 +113,15 @@ def show_tags(puzzle, tag_form, request):
     context = {
         'puzzle': puzzle,
         'current_tags': current_tags,
-        'tag_form': tag_form,
+        'tag_form': TagForm(),
         'suggestions': suggestions
     }
     return context
+
+@register.inclusion_tag('show_tags.html')
+def show_tags(puzzle, request):
+    return create_tag_context(puzzle)
+
 
 @register.filter(name='escape')
 @stringfilter

--- a/puzzles/urls.py
+++ b/puzzles/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("edit/<int:pk>/", views.edit_puzzle),
     path("delete/<int:pk>/", views.delete_puzzle),
     path("add_tag/<int:pk>/", views.add_tag),
+    path("add_tags_form/<int:pk>", views.add_tags_form),
     path("remove_tag/<int:pk>/<str:tag_text>", views.remove_tag),
     path("meta_select_form/<int:pk>", views.meta_select_form),
 ]

--- a/puzzles/utils.py
+++ b/puzzles/utils.py
@@ -1,3 +1,0 @@
-def to_tag(tag_string):
-    # Override default taggit behavior of splitting input string.
-    return [tag_string.upper()]

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from django.shortcuts import render, get_object_or_404
+from django.template.loader import render_to_string
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
@@ -220,6 +221,14 @@ def remove_tag(request, pk, tag_text):
     except ObjectDoesNotExist as e:
         messages.error(request, "Could not find the tag {} to remove".format(tag_text))
     return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+
+
+@login_required(login_url='/accounts/login/')
+def add_tags_form(request, pk):
+    puzzle = get_object_or_404(Puzzle, pk=pk)
+    context = puzzle_extras.create_tag_context(puzzle)
+    html = render_to_string('modals/tags_form.html', context, request)
+    return HttpResponse(html)
 
 
 @login_required(login_url='/accounts/login/')

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -13,6 +13,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from url_normalize import url_normalize
 
+from . import tag_utils
 from .models import *
 from .puzzle_tag import PuzzleTag
 from .forms import StatusForm, MetaPuzzleForm, PuzzleForm, TagForm
@@ -226,7 +227,17 @@ def remove_tag(request, pk, tag_text):
 @login_required(login_url='/accounts/login/')
 def add_tags_form(request, pk):
     puzzle = get_object_or_404(Puzzle, pk=pk)
-    context = puzzle_extras.create_tag_context(puzzle)
+    puzzle_tags = tag_utils.get_tags(puzzle)
+    all_tags = tag_utils.get_all_tags()
+
+    suggestions = [t for t in all_tags.items() if t not in puzzle_tags]
+    suggestions.sort(key=lambda item: (PuzzleTag.COLOR_ORDERING[item[1]], item[0]))
+
+    context = {
+        'puzzle': puzzle,
+        'suggestions': suggestions,
+        'tag_form': TagForm(),
+    }
     html = render_to_string('modals/tags_form.html', context, request)
     return HttpResponse(html)
 

--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -220,4 +220,4 @@ else:
     logger.warn('Google Drive integration not set up. All emails will be accepted.')
 
 # Taggit Overrides
-TAGGIT_TAGS_FROM_STRING = 'puzzles.utils.to_tag'
+TAGGIT_TAGS_FROM_STRING = 'puzzles.tag_utils.to_tag'


### PR DESCRIPTION
I followed in the footsteps of giants and copied the approach from #86 to remove pre-generation of all the tags modals and to fetch them on demand from the server.

With this change deployed, Small Board (with its ~70 puzzles) takes about 3 seconds to load (reduced from 5-6 seconds before) and data transferred is 456 KB (down from 1.1 MB):
![no-tags-modal](https://user-images.githubusercontent.com/544734/70966845-821c5480-2062-11ea-86ff-36ddafbe0eef.png)
