### PR TITLE
Render edit and delete puzzle modals on demand instead of pregenerating 2 modals per puzzle (#84)

### DIFF
--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -23,10 +23,10 @@
         </tr>
     </thead>
     <tbody>
-        {% for ans, form, notes_form in rows%}
+        {% for ans, edit_form, form, notes_form in rows%}
         <tr class="{% answer_class ans %}">
             <th>{{ ans.created_on }}</th>
-            <td>{% get_title ans.puzzle%}</td>
+            <td>{% get_title ans.puzzle edit_form %}</td>
             <td><p class="text-monospace">{{ ans.text.upper|strip }}</p></td>
             <td>
                 <form action="/answers/queue/{{ hunt_pk }}/{{ ans.id }}" method="post" class="form-inline">

--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -4,6 +4,9 @@
 
 {% block page_content %}
 
+{% include "modals/edit_puzzle.html" %}
+{% include "modals/delete_puzzle.html" %}
+
 <meta http-equiv="refresh" content="30">
 
 <div class="row justify-content-between" style="margin:10">
@@ -23,10 +26,10 @@
         </tr>
     </thead>
     <tbody>
-        {% for ans, edit_form, form, notes_form in rows%}
+        {% for ans, form, notes_form in rows%}
         <tr class="{% answer_class ans %}">
             <th>{{ ans.created_on }}</th>
-            <td>{% get_title ans.puzzle edit_form %}</td>
+            <td>{% get_title ans.puzzle %}</td>
             <td><p class="text-monospace">{{ ans.text.upper|strip }}</p></td>
             <td>
                 <form action="/answers/queue/{{ hunt_pk }}/{{ ans.id }}" method="post" class="form-inline">

--- a/answers/urls.py
+++ b/answers/urls.py
@@ -4,8 +4,8 @@ from django.http import HttpResponseRedirect
 from django.urls import path
 
 urlpatterns = [
-    path("queue/<int:hunk_pk>", AnswerView.as_view()),
-    path("queue/<int:hunk_pk>/<int:answer_pk>", AnswerView.as_view()),
+    path("queue/<int:hunt_pk>", AnswerView.as_view()),
+    path("queue/<int:hunt_pk>/<int:answer_pk>", AnswerView.as_view()),
     path("update_note/<int:answer_pk>", update_note, name="update_note"),
     path('', lambda r: HttpResponseRedirect('queue/{}'.format(settings.ACTIVE_HUNT_ID)), name="queue"),
 ]

--- a/answers/views.py
+++ b/answers/views.py
@@ -35,14 +35,13 @@ class AnswerView(LoginRequiredMixin, View):
     def get(self, request, hunt_pk):
         hunt = get_object_or_404(Hunt, pk=hunt_pk)
         answers = Answer.objects.filter(puzzle__hunt__pk=hunt_pk).order_by('-created_on')
-        edit_forms = [PuzzleForm(initial={'name': ans.puzzle.name, 'url': ans.puzzle.url, 'is_meta': ans.puzzle.is_meta}) for ans in answers]
         status_forms = [UpdateAnswerStatusForm(initial={'status': ans.get_status()}) for ans in answers]
         notes_forms = [UpdateAnswerNotesForm(initial={'text': ans.get_notes()}) for ans in answers]
 
         context = {
             'hunt_pk': hunt_pk,
             'hunt_name': hunt.name,
-            'rows' : zip(answers, edit_forms, status_forms, notes_forms)
+            'rows' : zip(answers, status_forms, notes_forms)
         }
         return render(request, 'queue.html', context)
 

--- a/puzzles/templates/modals/delete_puzzle.html
+++ b/puzzles/templates/modals/delete_puzzle.html
@@ -1,0 +1,33 @@
+<div class="modal fade" id="deletepuzzle" tabindex="-1" role="dialog" aria-labelledby="deletetitle" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deletetitle">Delete</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <form method="post" action="/puzzles/delete/">
+                {% csrf_token %}
+                <div class="modal-body">
+                    Are you sure you want to delete this puzzle?
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+$(function () {
+  $(".deletepuzzle").click(function() {
+    var pk = $(this).data("pk");
+    var name = $(this).data("name");
+    $('#deletepuzzle form').attr('action', `/puzzles/delete/${pk}/`);
+    $('#deletetitle').text(`Delete ${name}`);
+  })
+});
+</script>

--- a/puzzles/templates/modals/edit_puzzle.html
+++ b/puzzles/templates/modals/edit_puzzle.html
@@ -1,0 +1,50 @@
+<div class="modal fade" id="editpuzzle" tabindex="-1" role="dialog" aria-labelledby="edittitle" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="edittitle">Edit Puzzle</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <form method="post" action="/puzzles/edit/">
+                {% csrf_token %}
+                <div class="modal-body">
+                    <div class="form-group">
+                        <input class="form-control" type="text" name="name" value="" placeholder="Name of Puzzle" maxlength="128" required="" id="id_name">
+                    </div>
+                    <div class="form-group">
+                        <input class="form-control" type="text" name="url" value="" placeholder="URL" required="" id="id_url">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-check-label" for="id_is_meta">Meta?</label>
+                        <input type="checkbox" name="is_meta" id="id_is_meta">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Submit</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+$(function () {
+  $(".editpuzzle").click(function() {
+    var pk = $(this).data("pk");
+    var name = $(this).data("name");
+    var url = $(this).data("url");
+    var is_meta = $(this).data("is_meta");
+    $('#editpuzzle form').attr('action', `/puzzles/edit/${pk}/`);
+    $('#id_name').attr('value', name);
+    $('#id_url').attr('value', url);
+    if (is_meta.toLowerCase() === 'true') {
+        $('#id_is_meta').attr('checked', 'checked');
+    } else {
+        $('#id_is_meta').removeAttr('checked')
+    }
+  })
+});
+</script>

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -1,7 +1,8 @@
 {% load puzzle_extras %}
+{% include "modals/edit_puzzle.html" %}
+{% include "modals/delete_puzzle.html" %}
 {% include "modals/add_tag.html" %}
 {% include "modals/set_meta.html" %}
-
 
 <table class="table table-sm tree" id="puzzles" style="width:100%">
     <thead>
@@ -17,10 +18,10 @@
         </tr>
     </thead>
     <tbody>
-        {% for p, status_form, edit_form, puzzle_class in rows %}
+        {% for p, status_form, puzzle_class in rows %}
         <tr class="{{ puzzle_class }}">
             <td scope="row">
-                {% get_title p edit_form %}
+                {% get_title p %}
             </td>
             <td><p class="text-monospace">{{ p.answer.upper }}</p></td>
             <td>

--- a/puzzles/templates/title.html
+++ b/puzzles/templates/title.html
@@ -7,62 +7,9 @@
     <i class="fa fa-users" aria-hidden="true"></i>
 </span>
 {% endif %}
-<button type="button" class="btn btn-default" data-toggle="modal" data-target="#editpuzzle-{{ puzzle.pk }}" style="padding: 0px 0px;">
+<button type="button" class="editpuzzle btn btn-default" data-toggle="modal" data-target="#editpuzzle" data-pk="{{ puzzle.pk }}" data-name="{{ puzzle.name }}" data-url="{{ puzzle.url }}" data-is_meta="{{ puzzle.is_meta }}" style="padding: 0px 0px;">
     <i class="fa fa-edit" aria-hidden="true"></i>
 </button>
-<button type="button" class="btn btn-default" data-toggle="modal" data-target="#deletepuzzle-{{ puzzle.pk }}" style="padding: 0px 0px;">
+<button type="button" class="deletepuzzle btn btn-default" data-toggle="modal" data-target="#deletepuzzle" data-pk="{{ puzzle.pk }}" data-name="{{ puzzle.name }}" style="padding: 0px 0px;">
     <i class="fa fa-trash-o" aria-hidden="true"></i>
 </button>
-<div class="modal fade" id="editpuzzle-{{ puzzle.pk }}" tabindex="-1" role="dialog" aria-labelledby="edittitle-{{ puzzle.pk }}" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="edittitle-{{ puzzle.pk }}">Edit Puzzle</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <form method="post" action="/puzzles/edit/{{ puzzle.pk }}/">
-                {% csrf_token %}
-                <div class="modal-body">
-                    <div class="form-group">
-                        {{ edit_form.name }}
-                    </div>
-                    <div class="form-group">
-                        {{ edit_form.url }}
-                    </div>
-                    <div class="form-group">
-                        <label class="form-check-label" for="id_is_meta">Meta?</label>
-                        {{ edit_form.is_meta }}
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-primary">Submit</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
-<div class="modal fade" id="deletepuzzle-{{ puzzle.pk }}" tabindex="-1" role="dialog" aria-labelledby="deletetitle-{{ puzzle.pk }}" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="deletetitle-{{ puzzle.pk }}">Delete {{p.name}}</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <form method="post" action="/puzzles/delete/{{ puzzle.pk }}/">
-                {% csrf_token %}
-                <div class="modal-body">
-                    Are you sure you want to delete this puzzle?
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-danger">Delete</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>

--- a/puzzles/templatetags/puzzle_extras.py
+++ b/puzzles/templatetags/puzzle_extras.py
@@ -37,8 +37,6 @@ def get_table(puzzles, request):
             status_forms[i].fields["status"].choices =\
                 [(status, status) for status in Puzzle.VISIBLE_STATUS_CHOICES]
 
-    edit_forms = [PuzzleForm(initial={'name': p.name, 'url': p.url, 'is_meta': p.is_meta}) for p in sorted_puzzles]
-
     # this caches Puzzle.tags.all() for all the tag forms
     Puzzle.objects.all().prefetch_related('tags')
 
@@ -64,14 +62,14 @@ def get_table(puzzles, request):
     puzzle_class = __get_puzzle_class(sorted_np_pairs)
 
     context = {
-        'rows': zip(sorted_puzzles, status_forms, edit_forms, puzzle_class),
+        'rows': zip(sorted_puzzles, status_forms, puzzle_class),
         'guess_form': AnswerForm(),
         'slack_base_url': settings.SLACK_BASE_URL,
     }
     return context
 
 @register.inclusion_tag('title.html')
-def get_title(puzzle, edit_form):
+def get_title(puzzle):
     badge = ''
     if puzzle.is_meta:
         badge = 'META'
@@ -79,7 +77,6 @@ def get_title(puzzle, edit_form):
         'puzzle': puzzle,
         'active_users': puzzle.active_users.all(),
         'badge': badge,
-        'edit_form': edit_form,
     }
     return context
 


### PR DESCRIPTION
Instead of pregenerating 1 edit puzzle modal and 1 delete puzzle modal per puzzle, this PR changes the code to just reuse a single edit puzzle modal and a single delete puzzle modal across all puzzles, and uses JavaScript to update the modals when the edit or delete icons are clicked.

Data transferred and load time is further reduced with this change:

![edit-delete-modals](https://user-images.githubusercontent.com/544734/71228089-37434c80-22af-11ea-87b6-6a788dc07756.png)

Ignore the CircleCI results, since there's no config file until #97 is merged.