### PR TITLE
Enable paging by default and rerender treegrid on draw.dt events

### DIFF
--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -111,7 +111,8 @@ $(document).ready(function() {
     var pre_dt_init_ts = Date.now();
 
     var table = $('#puzzles').DataTable( {
-        "paging": false,
+        "paging": true,
+        "pageLength": 25,
         "info": false,
         "ordering": false,
         "columnDefs": [
@@ -131,6 +132,7 @@ $(document).ready(function() {
         }
     }
     table.on( 'search.dt', maybeExpandAll);
+
 
     var dt_init_ts = Date.now();
     var dt_init_ms = dt_init_ts - pre_dt_init_ts;
@@ -153,12 +155,19 @@ $(document).ready(function() {
     var pre_treegrid_ts = Date.now();
 
     // Initialize treegrid.
-    $('.tree').treegrid({
-        onCollapse: function() {
-            all_uncollapsed = false;
+    function initTreegrid() {
+        $('.tree').treegrid({
+            onCollapse: function() {
+                all_uncollapsed = false;
+            }
+        });
+        if ($('.tree').hasClass( "initial-collapsed" )) {
+            $('.initial-collapsed').treegrid('collapse');
         }
-    });
-    $('.initial-collapsed').treegrid('collapse');
+    }
+    initTreegrid();
+    // New datatable page and search should also trigger treegrid.
+    $('#puzzles').on( "draw.dt", initTreegrid);
 
     var treegrid_ts = Date.now();
     var treegrid_ms = treegrid_ts - pre_treegrid_ts;

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -61,11 +61,11 @@
             <th scope="col" class="column_searchable">Name</th>
             <th scope="col" class="column_searchable">Answer</th>
             <th scope="col" class="column_searchable">Status</th>
-            <th scope="col">Sheet</th>
-            <th scope="col">Slack</th>
+            <th scope="col"></th>
+            <th scope="col"></th>
             <th scope="col" class="column_searchable">Tags</th>
             <th scope="col"></th>
-            <th scope="col" class="column_searchable">Meta</th>
+            <th scope="col"></th>
         </tr>
     </tfoot>
 </table>
@@ -121,14 +121,27 @@ $(document).ready(function() {
         ]
     } );
 
+    // Move column search input to top.
+    $('#puzzles tfoot tr').appendTo('#puzzles thead');
+
+    function maybeExpandAll() {
+        if ( all_uncollapsed == false ) {
+            all_uncollapsed = true;
+            $('.tree').treegrid('expandAll');
+        }
+    }
+    table.on( 'search.dt', maybeExpandAll);
+
     var dt_init_ts = Date.now();
     var dt_init_ms = dt_init_ts - pre_dt_init_ts;
     console.log("Datatable init time (ms) :" + dt_init_ms);
 
+    var all_uncollapsed = false;
     // Apply column search.
     table.columns().every( function () {
         var that = this;
         $( 'input', this.footer() ).on( 'keyup change clear', function () {
+            maybeExpandAll();
             if ( that.search() !== this.value ) {
                 that
                     .search( this.value )
@@ -140,7 +153,11 @@ $(document).ready(function() {
     var pre_treegrid_ts = Date.now();
 
     // Initialize treegrid.
-    $('.tree').treegrid();
+    $('.tree').treegrid({
+        onCollapse: function() {
+            all_uncollapsed = false;
+        }
+    });
     $('.initial-collapsed').treegrid('collapse');
 
     var treegrid_ts = Date.now();

--- a/puzzles/templates/puzzles_table.html
+++ b/puzzles/templates/puzzles_table.html
@@ -83,18 +83,6 @@ $(document).ready(function() {
         return $(value).find('select').val();
     };
 
-    // For checkbox fields, each entry should only be searchable by the
-    // currently checked values.
-    $.fn.dataTableExt.ofnSearch['checkbox-input'] = function(value) {
-        var search_str = "";
-        $(value).find(":checked").each( function () {
-            // The name of the meta is actually displayed in the parent DOM
-            // element.
-            search_str += $(this).parent().text();
-        } );
-        return search_str;
-    };
-
     // For tags, each entry should be searchable by existing badges.
     $.fn.dataTableExt.ofnSearch['tag-input'] = function(value) {
         var search_str = "";
@@ -130,7 +118,6 @@ $(document).ready(function() {
             { "type": "name-input", "targets": [0] },
             { "type": "select-input", "targets": [2] },
             { "type": "tag-input", "targets": [5] },
-            { "type": "checkbox-input", "targets": [7] },
         ]
     } );
 


### PR DESCRIPTION
This means we rerender treegrid (should be cheap now that we have paging) on:
* new pages
* searches
![image](https://user-images.githubusercontent.com/1498449/71539711-6d677880-290e-11ea-9d98-0a9407d85148.png)

![image](https://user-images.githubusercontent.com/1498449/71539705-545ec780-290e-11ea-8294-aa2a6758329e.png)


