### PR TITLE
Add test that verifies Answer Queue page loads successfully

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           name: Running tests
           command: |
             . venv/bin/activate
+            python3 manage.py collectstatic
             python3 manage.py test --keepdb
       - store_artifacts:
           path: test-reports/

--- a/answers/tests.py
+++ b/answers/tests.py
@@ -23,6 +23,12 @@ class TestAnswers(TestCase):
     def tearDown(self):
         self._puzzle.delete()
         self._test_hunt.delete()
+        self._user.delete()
+
+
+    def test_answer_queue_page(self):
+        response = self.client.get('/answers/queue/' + str(self._test_hunt.pk))
+        self.assertEqual(response.status_code, 200)
 
 
     def test_answer_from_smallboard(self):


### PR DESCRIPTION
Answer Queue page was broken inadvertently in #118 (still needs to be fixed). But to prevent this from happening in the future, this PR adds a test that verifies `/answers/queue/X` returns 200. Ref: https://github.com/cardinalitypuzzles/smallboard/pull/118#pullrequestreview-337164371