### PR TITLE
Use prefetch_related('puzzle') on answers query

### DIFF
--- a/answers/views.py
+++ b/answers/views.py
@@ -48,7 +48,7 @@ def __answer_class(answer):
 @login_required(login_url='/accounts/login/')
 def answers(request, hunt_pk):
     hunt = get_object_or_404(Hunt, pk=hunt_pk)
-    answer_objects = Answer.objects.filter(puzzle__hunt__pk=hunt_pk).order_by('-created_on')
+    answer_objects = Answer.objects.filter(puzzle__hunt__pk=hunt_pk).prefetch_related('puzzle').order_by('-created_on')
 
     result = {
         "data": [


### PR DESCRIPTION
On Heroku:

before the change, fetching answers took ~3 sec:
![before-prefetch](https://user-images.githubusercontent.com/544734/71775374-f3f30a00-2f4d-11ea-89e7-5597c18e8a42.png)

after the change, it takes about 1.25 sec:
![after-prefetch](https://user-images.githubusercontent.com/544734/71775380-200e8b00-2f4e-11ea-92b2-c00f6a153ce9.png)
