### PR TITLE
Refresh Answer Queue table asynchronously (without full page reload), make update status asynchronous

### DIFF
--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -58,7 +58,7 @@ $(document).ready(function() {
             {'title': 'Status', 'targets': answer_status},
             {'title': 'Notes', 'targets': notes},
 
-            {'width': '15%', 'targets': time},
+            {'width': '15%', 'targets': [time, answer_status]},
 
             {
                 'targets': time,

--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -61,7 +61,7 @@ $(document).ready(function() {
             {
                 'targets': time,
                 'render': function(data, type, row, meta) {
-                    return moment(data).format('MMM D, YYYY, h:m a');
+                    return moment(data).format('MMM D, YYYY, hh:mm a');
                 },
             },
             {

--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -2,8 +2,6 @@
 
 {% block page_content %}
 
-<meta http-equiv="refresh" content="30">
-
 <div class="row justify-content-between" style="margin:10">
     <div class="col-10">
         <h1>{{ hunt_name }} - Answer Queue</h1>
@@ -30,7 +28,7 @@ $(document).ready(function() {
 
     let statuses = ['NEW', 'SUBMITTED', 'CORRECT', 'INCORRECT', 'PARTIAL',];
 
-    $('#queue').DataTable( {
+    let table = $('#queue').DataTable( {
         "ajax": "/answers/queue/{{hunt_pk}}/answers",
         "paging": true,
         "pageLength": 50,
@@ -41,6 +39,9 @@ $(document).ready(function() {
         "ordering": false,
         "createdRow": function(row, data, dataIndex) {
             $(row).addClass(data[answer_class]);
+        },
+        "initComplete": function(settings, json) {
+            initUpdateStatus(json['data'][0][id]);
         },
         "columnDefs": [
             {
@@ -85,12 +86,9 @@ $(document).ready(function() {
                     let result = data;
                     if (type === 'display') {
                         result = `
-    <form action="/answers/queue/{{ hunt_pk }}/${row[id]}" method="post" class="form-inline">
-        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
         <div class="form-group">
-            <select name="status" onChange="this.form.submit();" class="form-control form-control-sm">
+            <select name="status" class="form-control form-control-sm" id="answer-status-${row[id]}" data-id="${row[id]}">
     `;
-
                         for (const status of statuses) {
                             result += '<option value="' + status + '"';
                             if (status === data) {
@@ -101,8 +99,7 @@ $(document).ready(function() {
 
                         result += `
             </select>
-        </div>
-    </form>`;
+        </div>`;
                     }
                     return result;
                 },
@@ -127,6 +124,38 @@ $(document).ready(function() {
             },
         ],
     } );
+
+    function initUpdateStatus(maxId) {
+        for (let i = 0; i <= maxId; i++) {
+            $(`#answer-status-${i}`).change(function() {
+                $.ajax('/answers/queue/{{hunt_pk}}/' + $(this).data('id'), {
+                    'data': {
+                        'csrfmiddlewaretoken': '{{csrf_token}}',
+                        'status': $(this).val()
+                    },
+                    'method': 'POST',
+                    'success': function(response) {
+                        reload();
+                    },
+                    'error': function(response) {
+                        console.log('Got error response when updating answer:', response);
+                        reload();
+                    }
+                });
+            });
+        }
+    }
+
+    function reload() {
+        table.ajax.reload(function(response) {
+            // first element has max id
+            initUpdateStatus(response['data'][0][id]);
+        }, false /* resetPaging */);
+    }
+
+    setInterval(function() {
+        reload();
+    }, 10000);
 });
 </script>
 {% endblock %}

--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -29,7 +29,7 @@ $(document).ready(function() {
     let statuses = ['NEW', 'SUBMITTED', 'CORRECT', 'INCORRECT', 'PARTIAL',];
 
     let table = $('#queue').DataTable( {
-        "ajax": "/answers/queue/{{hunt_pk}}/answers",
+        "data": [],
         "paging": true,
         "pageLength": 50,
         "info": true,
@@ -39,9 +39,27 @@ $(document).ready(function() {
         "ordering": false,
         "createdRow": function(row, data, dataIndex) {
             $(row).addClass(data[answer_class]);
+            $(row).find(`#answer-status-${data[id]}`).change(function() {
+                $.ajax('/answers/queue/{{hunt_pk}}/' + $(this).data('id'), {
+                    'data': {
+                        'csrfmiddlewaretoken': '{{csrf_token}}',
+                        'status': $(this).val()
+                    },
+                    'method': 'POST',
+                    'success': function(response) {
+                        // Need to clear table so row gets redrawn with new background color
+                        table.clear();
+                        reload();
+                    },
+                    'error': function(response) {
+                        console.log('Got error response when updating answer:', response);
+                        reload();
+                    }
+                });
+            });
         },
-        "initComplete": function(settings, json) {
-            initUpdateStatus(json['data'][0][id]);
+        "initComplete": function(settings) {
+            reload();
         },
         "columnDefs": [
             {
@@ -127,37 +145,39 @@ $(document).ready(function() {
         ],
     } );
 
-    function initUpdateStatus(maxId) {
-        for (let i = 0; i <= maxId; i++) {
-            $(`#answer-status-${i}`).change(function() {
-                $.ajax('/answers/queue/{{hunt_pk}}/' + $(this).data('id'), {
-                    'data': {
-                        'csrfmiddlewaretoken': '{{csrf_token}}',
-                        'status': $(this).val()
-                    },
-                    'method': 'POST',
-                    'success': function(response) {
-                        reload();
-                    },
-                    'error': function(response) {
-                        console.log('Got error response when updating answer:', response);
-                        reload();
+    function reload() {
+        $.ajax('/answers/queue/{{hunt_pk}}/answers', {
+            'method': 'GET',
+            'success': function(newdata) {
+                newdata = newdata['data'];
+                olddata = table.data();
+                if (newdata.length !== olddata.length) {
+                    table.clear();
+                    for (const row of newdata) {
+                        table.row.add(row);
+                    }
+                    table.draw(false);
+                    return;
+                }
+
+                // diff row by row, invalidating updated rows
+                newdata.forEach(function(newrow, index1) {
+                    oldrow = olddata[index1];
+                    if (!newrow.every((value, index2) => value === oldrow[index2])) {
+                        table.row(index1).data(newrow);
+                        table.row(index1).invalidate();
                     }
                 });
-            });
-        }
-    }
-
-    function reload() {
-        table.ajax.reload(function(response) {
-            // first element has max id
-            initUpdateStatus(response['data'][0][id]);
-        }, false /* resetPaging */);
+            },
+            'error': function(response) {
+                console.log('Encountered error making /answers AJAX call:', response);
+            },
+        });
     }
 
     setInterval(function() {
         reload();
-    }, 10000);
+    }, 3000);
 });
 </script>
 {% endblock %}

--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -115,7 +115,7 @@ $(document).ready(function() {
     <div class="form-group">
         <input type="text" name="text" class="form-control form-control-sm col-xs-4" placeholder="Enter notes here" maxlength="128" required`;
                     if (data) {
-                        result += ` value=${data}`;
+                        result += ` value="${data}"`;
                     }
                     result += `>
         <button type="submit" class="btn btn-outline-primary btn-sm">Submit</button>

--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -58,6 +58,8 @@ $(document).ready(function() {
             {'title': 'Status', 'targets': answer_status},
             {'title': 'Notes', 'targets': notes},
 
+            {'width': '15%', 'targets': time},
+
             {
                 'targets': time,
                 'render': function(data, type, row, meta) {


### PR DESCRIPTION
Answer Queue page now refreshes asynchronously every 3 seconds, without a full page reload. Updating answer status also happens asynchronously and doesn't trigger full page reload.

Table is only redrawn if new answers have been submitted.

I plan to make updating the Notes field asynchronous (rather than triggering full page reload) in a subsequent PR.