### PR TITLE
Send answer queue messages to separate #answer-queue channel

### DIFF
--- a/answers/views.py
+++ b/answers/views.py
@@ -89,24 +89,25 @@ class AnswerView(LoginRequiredMixin, View):
         puzzle_channel = answer.puzzle.channel
         message = ''
         if status == Answer.NEW:
-            message = ("NEW answer '%s' has been guessed for puzzle '%s'." %
-                      (answer.text, answer.puzzle.name))
+            message = ("NEW answer '%s' has been guessed for puzzle '%s'."
+                       % (answer.text, answer.puzzle.name))
         elif status == Answer.SUBMITTED:
-            message = ("'%s' has been SUBMITTED for puzzle '%s' on the hunt website." %
-                      (answer.text, answer.puzzle.name))
+            message = ("'%s' has been SUBMITTED for puzzle '%s' on the hunt website."
+                       % (answer.text, answer.puzzle.name))
         elif status in [Answer.PARTIAL, Answer.INCORRECT, Answer.CORRECT]:
-            message = ("'%s' for puzzle '%s' is %s!" %
-                      (answer.text, answer.puzzle.name, status))
+            message = ("'%s' for puzzle '%s' is %s!"
+                       % (answer.text, answer.puzzle.name, status))
         else:
-            message = ("Unexpected status '%s' for answer '%s' for puzzle '%s'" %
-                      (status, answer.text, answer.puzzle.name))
+            logger.error("Unexpected status '%s' for answer '%s' for puzzle '%s'"
+                         % (status, answer.text, answer.puzzle.name))
+            return
 
         slack_client.send_message(puzzle_channel, message)
         slack_client.send_answer_queue_message(message)
         if status == Answer.CORRECT:
             slack_client.announce("'%s' has been solved with the answer: "
-                                   "\'%s\' Hurray!" %
-                                  (answer.puzzle.name, answer.text))
+                                  "\'%s\' Hurray!"
+                                  % (answer.puzzle.name, answer.text))
 
     @transaction.atomic
     def post(self, request, hunt_pk, answer_pk):

--- a/answers/views.py
+++ b/answers/views.py
@@ -97,6 +97,9 @@ class AnswerView(LoginRequiredMixin, View):
         elif status in [Answer.PARTIAL, Answer.INCORRECT, Answer.CORRECT]:
             message = ("'%s' for puzzle '%s' is %s!" %
                       (answer.text, answer.puzzle.name, status))
+        else:
+            message = ("Unexpected status '%s' for answer '%s' for puzzle '%s'" %
+                      (status, answer.text, answer.puzzle.name))
 
         slack_client.send_message(puzzle_channel, message)
         slack_client.send_answer_queue_message(message)

--- a/slack_lib/slack_client.py
+++ b/slack_lib/slack_client.py
@@ -23,7 +23,8 @@ class SlackClient:
         return SlackClient.__instance
 
 
-    def __init__(self, announcement_channel_name="announcements"):
+    def __init__(self, announcement_channel_name="announcements",
+                 answer_queue_channel_name="answer-queue"):
         ''' Private constructor. '''
         if SlackClient.__instance != None:
             raise Exception("SlackClient is a singleton and should not be "
@@ -36,6 +37,7 @@ class SlackClient:
                 self._enabled = True
                 self._web_client = slack.WebClient(token=token)
                 self.announcement_channel_name = announcement_channel_name
+                self.answer_queue_channel_name = answer_queue_channel_name
             else:
                 self._enabled = False
 
@@ -60,6 +62,11 @@ class SlackClient:
             return
 
         self._web_client.chat_postMessage(channel=channel, text=message)
+
+    def send_answer_queue_message(self, message):
+        if not self._enabled:
+            return
+        self.send_message(self.answer_queue_channel_name, message)
 
     def announce_puzzle_creation(self, puzzle_name, channel_id, is_meta=False):
         if not self._enabled:

--- a/slack_lib/slack_client.py
+++ b/slack_lib/slack_client.py
@@ -23,7 +23,7 @@ class SlackClient:
         return SlackClient.__instance
 
 
-    def __init__(self, announcement_channel_name="announcements",
+    def __init__(self, announcement_channel_name="puzzle-announcements",
                  answer_queue_channel_name="answer-queue"):
         ''' Private constructor. '''
         if SlackClient.__instance != None:


### PR DESCRIPTION
Changes:
* send answer status update messages to separate #answer-queue channel for easier monitoring by phone person
* add Slack messages for NEW and SUBMITTED status updates
* post CORRECT status update message to puzzle channel as well
* move puzzle creation and CORRECT answer messages from #announcements to #puzzle-announcements

Screenshots:

In puzzle channel:
![new-messages](https://user-images.githubusercontent.com/544734/71915757-6e887900-314a-11ea-9026-3b23fcc43598.png)

In #answer-queue channel:
![answer-queue](https://user-images.githubusercontent.com/544734/71915784-7811e100-314a-11ea-95f3-2f57de7a1809.png)

