### PR TITLE
Archive Slack channel on CORRECT answer

### DIFF
--- a/answers/views.py
+++ b/answers/views.py
@@ -12,6 +12,7 @@ from django.views import View
 from django.views.decorators.http import require_GET, require_POST
 from hunts.models import Hunt
 from puzzles.forms import PuzzleForm
+from puzzles.models import Puzzle
 from slack_lib.slack_client import SlackClient
 
 import logging

--- a/slack_lib/slack_client.py
+++ b/slack_lib/slack_client.py
@@ -134,6 +134,9 @@ class SlackClient:
         Given a channel_id (str, e.g. C1H9RESGL), returns the name of that
         human-readable channel name.
         '''
+        if not self._enabled:
+            return channel_id
+
         response = self._web_client.channels_info(channel=channel_id)
         return response["channel"]["name"]
 
@@ -156,5 +159,27 @@ class SlackClient:
         '''
         Given a Slack user id, returns the email address of the user.
         '''
+        if not self._enabled:
+            return user_id
+
         response = self._web_client.users_info(user=user_id)
         return response['user']['profile']['email']
+
+    def archive_channel(self, channel_id):
+        '''Archives a channel if it not archived'''
+        if not self._enabled:
+            return
+
+        response = self._web_client.channels_info(channel=channel_id)
+        if not response['channel']['is_archived']:
+            self._web_client.channels_archive(channel=channel_id)
+
+    def unarchive_channel(self, channel_id):
+        '''Unarchives a channel if it is archived'''
+        if not self._enabled:
+            return
+
+        response = self._web_client.channels_info(channel=channel_id)
+        if response['channel']['is_archived']:
+            self._web_client.channels_unarchive(channel=channel_id)
+


### PR DESCRIPTION
and unarchive it if answer status changed again to something else

![archive-unarchive](https://user-images.githubusercontent.com/544734/72010042-1f634680-3225-11ea-848f-00c1ab24c50c.png)

and edge case where one guess is marked CORRECT and then a different guess for the same puzzle is marked INCORRECT (we unarchive the channel temporarily to send the INCORRECT status update and then re-archive the channel):

![incorrect-after-correct](https://user-images.githubusercontent.com/544734/72012640-41ab9300-322a-11ea-8283-0922050833a1.png)


For #133