### PR TITLE
Share puzzle link and sheet link in Slack messages

### DIFF
--- a/hunts/views.py
+++ b/hunts/views.py
@@ -117,7 +117,9 @@ class HuntView(LoginRequiredMixin, View):
                     channel=channel_id if channel_id else name
                 )
                 # Announce new puzzle is available on slack.
-                slack_client.announce_puzzle_creation(name, channel_id, is_meta)
+                slack_client.announce_puzzle_creation(name, puzzle_url,
+                                                      channel_id, sheet,
+                                                      is_meta)
 
             except IntegrityError as e:
                 # TODO(asdfryan): Think about cleaning up dangling sheets / slack channels.

--- a/slack_lib/slack_client.py
+++ b/slack_lib/slack_client.py
@@ -68,19 +68,25 @@ class SlackClient:
             return
         self.send_message(self.answer_queue_channel_name, message)
 
-    def announce_puzzle_creation(self, puzzle_name, channel_id, is_meta=False):
+    def announce_puzzle_creation(self, puzzle_name, puzzle_url, channel_id,
+                                 sheet_url, is_meta=False):
         if not self._enabled:
             return
 
-        channel_name = self.get_channel_name(channel_id)
         puzzle_type = "MetaPuzzle" if is_meta else "Puzzle"
         self.announce(
-                      "Channel %s created for a new %s titled %s!" %
-                      (channel_name, puzzle_type, puzzle_name))
+                      "Channel <#%s> created for a new %s titled '%s'!\n"
+                      "Puzzle link: %s\n"
+                      "Spreadsheet: %s" %
+                      (channel_id, puzzle_type, puzzle_name, puzzle_url,
+                       sheet_url))
         self.send_message(channel_id,
                       "This channel has been registered with the "
-                      "%s titled %s. You may submit answers via "
-                      "the /answer command." % (puzzle_type, puzzle_name))
+                      "%s titled '%s'. You may submit answers via "
+                      "the /answer command.\n"
+                      "Puzzle link: %s\n"
+                      "Spreadsheet: %s" %
+                      (puzzle_type, puzzle_name, puzzle_url, sheet_url))
 
     def create_or_join_channel(self, puzzle_name):
         '''


### PR DESCRIPTION
In #puzzle-announcements:
![puzzle-announcement](https://user-images.githubusercontent.com/544734/72023946-2fd5ea00-3242-11ea-9895-730564a24c42.png)

In puzzle channel:
![puzzle-channel](https://user-images.githubusercontent.com/544734/72023947-2fd5ea00-3242-11ea-837c-fb9241ed471c.png)

Also linkified the Slack channel name posted to the #puzzle-announcements channel.

For #134.