### PR TITLE
Support updating Notes for answer asynchronously

### DIFF
--- a/answers/forms.py
+++ b/answers/forms.py
@@ -26,5 +26,6 @@ class UpdateAnswerNotesForm(forms.Form):
         widget=forms.TextInput(attrs={
             "class": "form-control form-control-sm",
             "placeholder": "Enter notes here"
-        })
+        }),
+        required=False,
     )

--- a/answers/templates/queue.html
+++ b/answers/templates/queue.html
@@ -57,11 +57,13 @@ $(document).ready(function() {
         "ordering": false,
         "createdRow": function(row, data, dataIndex) {
             $(row).addClass(getTableClassForAnswerStatus(data[answer_status]));
-            $(row).find(`#answer-status-${data[id]}`).change(function() {
+
+            // register status update handler
+            $('#queue').on('change', `#answer-status-${data[id]}`, function() {
                 let newStatus = $(this).val();
                 updateRowColor(row, newStatus);
                 data[answer_status] = newStatus;
-                $.ajax('/answers/queue/{{hunt_pk}}/' + $(this).data('id'), {
+                $.ajax(`/answers/queue/{{hunt_pk}}/${data[id]}`, {
                     'data': {
                         'csrfmiddlewaretoken': '{{csrf_token}}',
                         'status': newStatus
@@ -72,6 +74,26 @@ $(document).ready(function() {
                     },
                     'error': function(response) {
                         console.log('Got error response when updating answer:', response);
+                        reload();
+                    }
+                });
+            });
+
+            // register notes update handler
+            $('#queue').on('submit', `#notes-${data[id]}`, function(e) {
+                e.preventDefault();
+                // flash the row for visual feedback
+                $(row).hide();
+                $(row).fadeIn('slow');
+                data[notes] = $(this).find('.notes-value').val();
+                $.ajax(`/answers/update_note/${data[id]}`, {
+                    'method': 'POST',
+                    'data': $(this).serialize(),
+                    'success': function(response) {
+                        reload();
+                    },
+                    'error': function(response) {
+                        console.log('Got error when updating notes:', response);
                         reload();
                     }
                 });
@@ -126,7 +148,7 @@ $(document).ready(function() {
                     if (type === 'display') {
                         result = `
         <div class="form-group">
-            <select name="status" class="form-control form-control-sm" id="answer-status-${row[id]}" data-id="${row[id]}">
+            <select name="status" class="form-control form-control-sm" id="answer-status-${row[id]}">
     `;
                         for (const status of statuses) {
                             result += '<option value="' + status + '"';
@@ -147,10 +169,10 @@ $(document).ready(function() {
                 'targets': notes,
                 'render': function(data, type, row, meta) {
                     let result = `
-<form action="/answers/update_note/${row[id]}" method="post" class="form-inline">
+<form method="post" class="form-inline" id="notes-${row[id]}">
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
     <div class="form-group">
-        <input type="text" name="text" class="form-control form-control-sm col-xs-4" placeholder="Enter notes here" maxlength="128" required`;
+        <input type="text" name="text" class="notes-value form-control form-control-sm col-xs-4" placeholder="Enter notes here" maxlength="128"`;
                     if (data) {
                         result += ` value="${data}"`;
                     }


### PR DESCRIPTION
I think I'm finally starting to understand how JavaScript handlers work...

Changes:
* support updating Notes without page reload. The table row flashes (disappears and fades in) as visual feedback upon submitting the Notes field
* added support for clearing deleted Notes (by making it not a required field)