### PR TITLE
Fix missing colors in dropdown in "Add Tag" form

### DIFF
--- a/puzzles/puzzle_tag.py
+++ b/puzzles/puzzle_tag.py
@@ -19,9 +19,14 @@ class PuzzleTag(TagBase):
         BLACK : "black"
     }
     RESERVED = [GREEN, RED, YELLOW, BLACK]
-    VISIBLE_COLOR_CHOICES = filter(lambda c : c[0] not in PuzzleTag.RESERVED, COLORS.items())
 
-    COLOR_ORDERING = {k: v for v, k in enumerate([RED, BLACK, WHITE, GRAY, BLUE, GREEN, YELLOW])}
+    @classmethod
+    def visible_color_choices(cls):
+        return list(filter(lambda c : c[0] not in cls.RESERVED, cls.COLORS.items()))
+
+    @classmethod
+    def color_ordering(cls):
+        return {k: v for v, k in enumerate([cls.RED, cls.BLACK, cls.WHITE, cls.GRAY, cls.BLUE, cls.GREEN, cls.YELLOW])}
 
     color = models.CharField(
         max_length=10,

--- a/puzzles/tag_utils.py
+++ b/puzzles/tag_utils.py
@@ -19,7 +19,7 @@ def to_tag(tag_string):
 
 def get_tags(puzzle):
     puzzle_tags = [[t.name, t.color] for t in puzzle.tags.all()]
-    puzzle_tags.sort(key=lambda item: (PuzzleTag.COLOR_ORDERING[item[1]], item[0]))
+    puzzle_tags.sort(key=lambda item: (PuzzleTag.color_ordering()[item[1]], item[0]))
     return puzzle_tags
 
 

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -277,11 +277,11 @@ def add_tags_form(request, pk):
     all_tags = tag_utils.get_all_tags()
 
     suggestions = [t for t in all_tags.items() if t not in puzzle_tags]
-    suggestions.sort(key=lambda item: (PuzzleTag.COLOR_ORDERING[item[1]], item[0]))
+    suggestions.sort(key=lambda item: (PuzzleTag.color_ordering()[item[1]], item[0]))
 
     tag_form = TagForm()
     # For custom tags, we want to limit color choices to non-reserved colors.
-    tag_form.fields['color'].choices = PuzzleTag.VISIBLE_COLOR_CHOICES
+    tag_form.fields['color'].choices = PuzzleTag.visible_color_choices()
 
     context = {
         'puzzle': puzzle,


### PR DESCRIPTION
Intermittently, in the "Add Tag" form, there will not be any options in the color dropdown menu:
![no-colors](https://user-images.githubusercontent.com/544734/72198979-44151500-3403-11ea-86b9-d54c621c587b.png)

This seems to be due to some class initialization race condition. By generating the visible color choices and color ordering in class methods, the issue goes away.