### PR TITLE
Support adding and deleting tags without reload

### DIFF
--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -212,6 +212,7 @@ $(document).ready(function() {
         'createdRow': function(row, data, dataIndex) {
             $(row).addClass(data[puzzle_class]);
             $(row).attr('id', `puzzle-${data[pk]}`);
+            initDeleteTagHandlers(data);
         },
         'drawCallback': function() {
             $('#puzzles').on('draw.dt', initTreegrid);

--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -189,12 +189,12 @@ function initDeleteTagHandlers(data) {
                 'method': 'POST',
                 'data': $(this).serialize(),
                 'success': function() {
-                    showMessage(`Removed tag ${tagName} from puzzle ${data[name]}`);
+                    showMessage(`Removed tag '${tagName}' from puzzle '${data[puzzle_name]}'`);
                     reload();
                 },
                 'error': function(response) {
                     response = response['responseJSON'];
-                    let message = `Got error deleting tag ${tagName} from puzzle ${data[name]}: ${response['error']}`;
+                    let message = `Got error deleting tag '${tagName}' from puzzle '${data[puzzle_name]}': ${response['error']}`;
                     showMessage(message, 'error');
                     reload();
                 },

--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -136,6 +136,20 @@ function reload() {
     });
 }
 
+function showMessage(message, type) {
+    let alertClass = 'alert-success';
+    if (type === 'error') {
+        alertClass = 'alert-danger'
+    }
+
+    $('#ajax-messages').html(`
+        <div class="alert ${alertClass} alert-dismissible fade show">
+            ${message}
+            <button type="button" class="close" data-dismiss="alert">&times;</button>
+        </div>`
+    );
+}
+
 $(document).ready(function() {
     table = $('#puzzles').DataTable({
         'data': [],
@@ -145,6 +159,38 @@ $(document).ready(function() {
         'createdRow': function(row, data, dataIndex) {
             $(row).addClass(data[puzzle_class]);
             $(row).attr('id', `puzzle-${data[pk]}`);
+
+            // add delete tag handlers
+            let puzzleTags = data[tags];
+            for (let i = 0; i < puzzleTags.length; i++) {
+                let tagName = puzzleTags[i][0];
+                $('#puzzles').on('submit', `.delete-tag-${data[pk]}-${tagName}`, function(e) {
+                    console.log("submitting");
+                    e.preventDefault();
+
+                    // to prevent form submission from being triggered for every instance of
+                    // this puzzle (which might be listed under multiple metas)
+                    e.stopImmediatePropagation();
+
+                    puzzleTags.splice(i, 1);
+                    table.row(`#puzzle-${data[pk]}`).invalidate();
+                    let url = $(this).attr('action');
+                    $.ajax(url, {
+                        'method': 'POST',
+                        'data': $(this).serialize(),
+                        'success': function() {
+                            showMessage(`Removed tag ${tagName} from puzzle ${data[name]}`);
+                            reload();
+                        },
+                        'error': function(response) {
+                            response = response['responseJSON'];
+                            let message = `Got error deleting tag ${tagName} from puzzle ${data[name]}: ${response['error']}`;
+                            showMessage(message, 'error');
+                            reload();
+                        },
+                    });
+                });
+            }
         },
         'drawCallback': function() {
             $('#puzzles').on('draw.dt', initTreegrid);
@@ -253,7 +299,7 @@ $(document).ready(function() {
                     for (var i = 0; i < data.length; i++) {
                         tag = data[i];
                         result += `
-    <form method="post" action="/puzzles/remove_tag/${row[pk]}/${tag[0]}">
+    <form method="post" action="/puzzles/remove_tag/${row[pk]}/${tag[0]}" class="delete-tag-${row[pk]}-${tag[0]}">
         <input type="hidden" name="csrfmiddlewaretoken" value="{{csrf_token}}">
         <small>
             <span class="badge badge-${tag[1]}">${tag[0]}</span>

--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -123,6 +123,8 @@ function reload() {
                     table.row(rowIndex).data(newrow);
                     table.row(rowIndex).invalidate();
                     updateRowColor(rowIndex, newrow[puzzle_status]);
+                    initDeleteTagHandlers(newrow);
+                    initTreegrid();
                 }
             });
 
@@ -134,6 +136,25 @@ function reload() {
             console.log('Encountered error making /puzzles AJAX call:', response);
         },
     });
+}
+
+var all_uncollapsed = false;
+function maybeExpandAll() {
+    if ( all_uncollapsed == false ) {
+        all_uncollapsed = true;
+        $('.tree').treegrid('expandAll');
+    }
+}
+
+function initTreegrid() {
+    $('.tree').treegrid({
+        onCollapse: function() {
+            all_uncollapsed = false;
+        }
+    });
+    if ($('.tree').hasClass( "initial-collapsed" )) {
+        $('.initial-collapsed').treegrid('collapse');
+    }
 }
 
 function showMessage(message, type) {
@@ -150,6 +171,38 @@ function showMessage(message, type) {
     );
 }
 
+function initDeleteTagHandlers(data) {
+    let puzzleTags = data[tags];
+    for (let i = 0; i < puzzleTags.length; i++) {
+        let tagName = puzzleTags[i][0];
+        $('#puzzles').on('submit', `.delete-tag-${data[pk]}-${tagName}`, function(e) {
+            let url = $(this).attr('action');
+            e.preventDefault();
+
+            // to prevent form submission from being triggered for every instance of
+            // this puzzle (which might be listed under multiple metas)
+            e.stopImmediatePropagation();
+
+            puzzleTags.splice(i, 1);
+            table.cell(`#puzzle-${data[pk]}`, tags).invalidate();
+            $.ajax(url, {
+                'method': 'POST',
+                'data': $(this).serialize(),
+                'success': function() {
+                    showMessage(`Removed tag ${tagName} from puzzle ${data[name]}`);
+                    reload();
+                },
+                'error': function(response) {
+                    response = response['responseJSON'];
+                    let message = `Got error deleting tag ${tagName} from puzzle ${data[name]}: ${response['error']}`;
+                    showMessage(message, 'error');
+                    reload();
+                },
+            });
+        });
+    }
+}
+
 $(document).ready(function() {
     table = $('#puzzles').DataTable({
         'data': [],
@@ -159,38 +212,6 @@ $(document).ready(function() {
         'createdRow': function(row, data, dataIndex) {
             $(row).addClass(data[puzzle_class]);
             $(row).attr('id', `puzzle-${data[pk]}`);
-
-            // add delete tag handlers
-            let puzzleTags = data[tags];
-            for (let i = 0; i < puzzleTags.length; i++) {
-                let tagName = puzzleTags[i][0];
-                $('#puzzles').on('submit', `.delete-tag-${data[pk]}-${tagName}`, function(e) {
-                    console.log("submitting");
-                    e.preventDefault();
-
-                    // to prevent form submission from being triggered for every instance of
-                    // this puzzle (which might be listed under multiple metas)
-                    e.stopImmediatePropagation();
-
-                    puzzleTags.splice(i, 1);
-                    table.row(`#puzzle-${data[pk]}`).invalidate();
-                    let url = $(this).attr('action');
-                    $.ajax(url, {
-                        'method': 'POST',
-                        'data': $(this).serialize(),
-                        'success': function() {
-                            showMessage(`Removed tag ${tagName} from puzzle ${data[name]}`);
-                            reload();
-                        },
-                        'error': function(response) {
-                            response = response['responseJSON'];
-                            let message = `Got error deleting tag ${tagName} from puzzle ${data[name]}: ${response['error']}`;
-                            showMessage(message, 'error');
-                            reload();
-                        },
-                    });
-                });
-            }
         },
         'drawCallback': function() {
             $('#puzzles').on('draw.dt', initTreegrid);
@@ -329,25 +350,6 @@ $(document).ready(function() {
             }
         ],
     });
-
-    var all_uncollapsed = false;
-    function maybeExpandAll() {
-        if ( all_uncollapsed == false ) {
-            all_uncollapsed = true;
-            $('.tree').treegrid('expandAll');
-        }
-    }
-
-    function initTreegrid() {
-        $('.tree').treegrid({
-            onCollapse: function() {
-                all_uncollapsed = false;
-            }
-        });
-        if ($('.tree').hasClass( "initial-collapsed" )) {
-            $('.initial-collapsed').treegrid('collapse');
-        }
-    }
 
     setInterval(function() {
         reload();

--- a/puzzles/templates/modals/submit_answer.html
+++ b/puzzles/templates/modals/submit_answer.html
@@ -52,7 +52,8 @@ $('#submitanswer form').on('submit', function(e) {
     let rowNode = row.node();
     let data = row.data();
     let puzzleName = data[puzzle_name];
-    data[status] = 'PENDING';
+    data[puzzle_status] = 'PENDING';
+    table.cell(row.index(), puzzle_status).invalidate();
     updateRowColor(rowNode, 'PENDING');
 
     $.ajax(url, {
@@ -63,13 +64,11 @@ $('#submitanswer form').on('submit', function(e) {
             reload();
         },
         'error': function(response) {
-            showMessage(`Got error submitting guess ${guess} for puzzle ${puzzleName}: ${response['responseJSON']['error']}`);
+            showMessage(`Got error submitting guess ${guess} for puzzle ${puzzleName}: ${response['responseJSON']['error']}`, 'error');
             reload();
         },
     });
 
     $('#submitanswer').modal('hide');
-
-    row.invalidate();
 })
 </script>

--- a/puzzles/templates/modals/submit_answer.html
+++ b/puzzles/templates/modals/submit_answer.html
@@ -26,10 +26,10 @@
 <script type="text/javascript">
 function submitAnswerHandler(e) {
     var pk = $(this).data("pk");
-    var name = $(this).data("name");
+    var puzzleName = $(this).data("name");
     $('#submitanswer form').attr('action', `/puzzles/guess/${pk}/`);
     $('#submitanswer form').data('pk', pk);
-    $('#submitanswer-puzzle-name').text(name);
+    $('#submitanswer-puzzle-name').text(puzzleName);
     $('#guess-input').val('');
 
     // Need to set focus after delay to accommodate fade in
@@ -37,15 +37,21 @@ function submitAnswerHandler(e) {
         $('#guess-input').focus();
     }, 350);
 }
-
 $('#puzzles').on('click', '.submitanswer', submitAnswerHandler);
+
+function sanitizeGuess(guess) {
+    return guess.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+}
+
 $('#submitanswer form').on('submit', function(e) {
     e.preventDefault();
     let pk = $(this).data('pk');
     let url = $(this).attr('action');
+    let guess = sanitizeGuess($('#guess-input').val());
     let row = table.row(`#puzzle-${pk}`);
     let rowNode = row.node();
     let data = row.data();
+    let puzzleName = data[puzzle_name];
     data[status] = 'PENDING';
     updateRowColor(rowNode, 'PENDING');
 
@@ -53,10 +59,11 @@ $('#submitanswer form').on('submit', function(e) {
         'method': 'POST',
         'data': $(this).serialize(),
         'success': function(response) {
+            showMessage(`Submitted guess ${guess} for puzzle ${puzzleName}`);
             reload();
         },
         'error': function(response) {
-            console.log('Got error submitting guess', guess, 'for puzzle', pk, ':', response);
+            showMessage(`Got error submitting guess ${guess} for puzzle ${puzzleName}: ${response['responseJSON']['error']}`);
             reload();
         },
     });

--- a/puzzles/templates/modals/submit_answer.html
+++ b/puzzles/templates/modals/submit_answer.html
@@ -60,11 +60,11 @@ $('#submitanswer form').on('submit', function(e) {
         'method': 'POST',
         'data': $(this).serialize(),
         'success': function(response) {
-            showMessage(`Submitted guess ${guess} for puzzle ${puzzleName}`);
+            showMessage(`Submitted guess '${guess}' for puzzle '${puzzleName}'`);
             reload();
         },
         'error': function(response) {
-            showMessage(`Got error submitting guess ${guess} for puzzle ${puzzleName}: ${response['responseJSON']['error']}`, 'error');
+            showMessage(`Got error submitting guess '${guess}' for puzzle '${puzzleName}': ${response['responseJSON']['error']}`, 'error');
             reload();
         },
     });

--- a/puzzles/templates/modals/tags_form.html
+++ b/puzzles/templates/modals/tags_form.html
@@ -6,7 +6,7 @@
             </div>
             <div class="modal-body">
                 {% for tag, class in suggestions %}
-                    <form  style="display: inline;" method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/">
+                    <form  style="display: inline;" method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/" class='add-existing-tag-form'>
                         {% csrf_token %}
                         <input type="hidden" name="name" value="{{ tag }}">
                         <input type="hidden" name="color" value="{{ class }}">
@@ -18,7 +18,7 @@
                 <button type="button" class="btn btn-info btn-sm btn-block" data-toggle="collapse" data-target="#collapseTagInput" aria-expanded="false" aria-controls="collapseTagInput"> <i class="fa fa fa-plus" aria-hidden="true"></i> Add New Tag </button>
                 <div class="collapse" id="collapseTagInput">
                   <div class="card card-body">
-                    <form method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/">
+                    <form method="post" action="/puzzles/add_tag/{{ puzzle.pk }}/" id='add-new-tag-form'>
                         {% csrf_token %}
                         <div class="form-group">
                             {{ tag_form.name }}
@@ -32,3 +32,35 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
             </div>
+
+<script type='text/javascript'>
+$('.add-existing-tag-form, #add-new-tag-form').on('submit', function(e) {
+    e.preventDefault();
+
+    let row = table.row(`#puzzle-{{puzzle.pk}}`);
+    let url = $(this).attr('action');
+    let values = {};
+    $.each($(this).serializeArray(), function(i, field) {
+        values[field.name] = field.value;
+    });
+
+    row.data()[tags].push([values['name'], values['color']]);
+    table.cell(row.index(), tags).invalidate();
+    initDeleteTagHandlers(row.data());
+
+    $.ajax(url, {
+        'method': 'POST',
+        'data': $(this).serialize(),
+        'success': function() {
+            showMessage(`Added tag ${values['name']} to puzzle {{puzzle.name}}`);
+            reload();
+        },
+        'error': function(response) {
+            showMessage(`Encountered error adding tag ${values['name']} to puzzle {{puzzle.name}}: ${response['responseJSON']['error']}`, 'error');
+            reload();
+        },
+    });
+
+    $('#addtag').modal('hide');
+});
+</script>

--- a/puzzles/templates/modals/tags_form.html
+++ b/puzzles/templates/modals/tags_form.html
@@ -52,11 +52,11 @@ $('.add-existing-tag-form, #add-new-tag-form').on('submit', function(e) {
         'method': 'POST',
         'data': $(this).serialize(),
         'success': function() {
-            showMessage(`Added tag ${values['name']} to puzzle {{puzzle.name}}`);
+            showMessage(`Added tag '${values['name']}' to puzzle '{{puzzle.name}}'`);
             reload();
         },
         'error': function(response) {
-            showMessage(`Encountered error adding tag ${values['name']} to puzzle {{puzzle.name}}: ${response['responseJSON']['error']}`, 'error');
+            showMessage(`Encountered error adding tag '${values['name']}' to puzzle '{{puzzle.name}}': ${response['responseJSON']['error']}`, 'error');
             reload();
         },
     });

--- a/smallboard/templates/base.html
+++ b/smallboard/templates/base.html
@@ -70,7 +70,7 @@
 
         </nav>
 
-
+        <div id='ajax-messages'></div>
         {% for message in messages %}
         {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}
             <div class="alert alert-danger" style="white-space: pre-line" role="alert">{{ message }}</div>


### PR DESCRIPTION
Changes:
* made adding and removing tags asynchronous (no reload)
* added alert message on AJAX success / error

Add tag message:
![add-tag](https://user-images.githubusercontent.com/544734/72199748-2f8a4a00-340e-11ea-998c-94666555d842.png)

Remove tag message:
![remove-tag](https://user-images.githubusercontent.com/544734/72199752-36b15800-340e-11ea-9a37-4be994b7a42e.png)

Submit answer message:
![submitted-guess](https://user-images.githubusercontent.com/544734/72199757-3b760c00-340e-11ea-9efd-45a8a2e640e5.png)

Trying to delete meta tag from meta:
![delete-meta](https://user-images.githubusercontent.com/544734/72199767-67918d00-340e-11ea-9688-5408a721c4c0.png)

This PR includes the commits from #144.