### PR TITLE
Add INTERACTIVE as a default tag

### DIFF
--- a/puzzles/tag_utils.py
+++ b/puzzles/tag_utils.py
@@ -9,6 +9,7 @@ DEFAULT_TAGS = [
     ('LOGIC', PuzzleTag.WHITE),
     ('TECHNICAL', PuzzleTag.WHITE),
     ('SLOG', PuzzleTag.GRAY),
+    ('INTERACTIVE', PuzzleTag.BLUE),
 ]
 
 


### PR DESCRIPTION
For puzzles that require going somewhere on-campus.
![interactive-tag](https://user-images.githubusercontent.com/544734/72214491-46de3b80-34d1-11ea-8e5b-e6a74267c7dc.png)
