### PR TITLE
Support updating puzzle status without page reload

### DIFF
--- a/puzzles/templates/modals/edit_status.html
+++ b/puzzles/templates/modals/edit_status.html
@@ -7,7 +7,7 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <form method="post" action="/puzzles/update_status/" onsubmit="return disableSubmit(this);">
+            <form id='edit-status' method="post" action="/puzzles/update_status/">
                 {% csrf_token %}
                 <div class="modal-body">
                     <div class="form-group">
@@ -35,7 +35,39 @@ function editStatusHandler() {
     $('#editstatus form').attr('action', `/puzzles/update_status/${pk}/`);
     $('#puzzletitle').text(name);
     $(`#editstatus option[value="${puzzleStatus}"]`).attr('selected', 'selected');
+    $('#edit-status').data('pk', pk);
 }
 
 $('#puzzles').on('click', '.editstatus', editStatusHandler);
+
+$('#edit-status').on('submit', function(e) {
+    e.preventDefault();
+
+    let pk = $(this).data('pk');
+    let url = $(this).attr('action');
+    let row = table.row(`#puzzle-${pk}`);
+    let puzzleName = row.data()[puzzle_name];
+
+    let newStatus = $(this).find('option:selected').val();
+    row.data()[puzzle_status] = newStatus;
+    table.cell(row.index(), puzzle_status).invalidate();
+    updateRowColor(row.node(), newStatus);
+
+    $.ajax(url, {
+        'method': 'POST',
+        'data': $(this).serialize(),
+        'success': function() {
+            showMessage(`Updated status for puzzle '${puzzleName}' to ${newStatus}`);
+            reload();
+        },
+        'error': function(response) {
+            showMessage('Encountered error updating status for puzzle ' +
+                `'${puzzleName}' to ${newStatus}: ` +
+                `${response['responseJSON']['error']}`, 'error');
+            reload();
+        },
+    });
+
+    $('#editstatus').modal('hide');
+});
 </script>

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -38,11 +38,12 @@ def index(request, pk):
 @require_POST
 @login_required(login_url='/accounts/login/')
 def update_status(request, pk):
-    if request.method == 'POST':
-        form = StatusForm(request.POST, instance=get_object_or_404(Puzzle, pk=pk))
-        if form.is_valid():
-            form.save()
-    return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+    form = StatusForm(request.POST, instance=get_object_or_404(Puzzle, pk=pk))
+    if not form.is_valid():
+        return JsonResponse({'error': 'Invalid update puzzle status form'},
+            status=400)
+    form.save()
+    return JsonResponse({})
 
 
 def __sanitize_guess(guess):


### PR DESCRIPTION
Here's what the update puzzle status message looks like:

![update-status](https://user-images.githubusercontent.com/544734/72394363-f1d63b80-3703-11ea-88f0-61cf75b38a97.png)
