### PR TITLE
 Support editing puzzle (name, URL, is_meta) without page reload

### DIFF
--- a/puzzles/templates/modals/edit_puzzle.html
+++ b/puzzles/templates/modals/edit_puzzle.html
@@ -7,7 +7,7 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <form method="post" action="/puzzles/edit/" onsubmit="return disableSubmit(this);">
+            <form id='edit-puzzle' method="post" action="/puzzles/edit/">
                 {% csrf_token %}
                 <div class="modal-body">
                     <div class="form-group">
@@ -36,7 +36,7 @@ function editPuzzleHandler() {
     var name = $(this).data("name");
     var url = $(this).data("url");
     var is_meta = $(this).data("is_meta");
-    $('#editpuzzle form').attr('action', `/puzzles/edit/${pk}/`);
+    $('#edit-puzzle').attr('action', `/puzzles/edit/${pk}/`);
     $('#id_name').attr('value', name);
     $('#id_url').attr('value', url);
     if (is_meta) {
@@ -44,7 +44,67 @@ function editPuzzleHandler() {
     } else {
         $('#id_is_meta').removeAttr('checked');
     }
+    $('#edit-puzzle').data('pk', pk);
+
+    // Need to set focus after delay to accommodate fade in
+    setTimeout(function() {
+        $('#id_name').focus();
+    }, 500);
 }
 
 $('#puzzles').on('click', '.editpuzzle', editPuzzleHandler);
+
+$('#edit-puzzle').on('submit', function(e) {
+    e.preventDefault();
+
+    let pk = $(this).data('pk');
+    let ajaxUrl = $(this).attr('action');
+    let row = table.row(`#puzzle-${pk}`);
+    let rowIndex = row.index();
+    let data = row.data();
+    let oldPuzzleName = data[puzzle_name];
+
+    let values = {};
+    $.each($(this).serializeArray(), function(i, field) {
+        values[field.name] = field.value;
+    });
+    let newPuzzleName = values['name'];
+
+    data[puzzle_name] = newPuzzleName;
+    data[url] = values['url'];
+    data[is_meta] = values['is_meta'] == 'on' ? true : false;
+
+    let newTags = [];
+    data[tags].forEach(function(tag, index) {
+        if (tag[0] == oldPuzzleName) {
+            if (data[is_meta]) {
+                newTags.push([newPuzzleName, 'dark']);
+            }
+        } else {
+            newTags.push(tag);
+        }
+    });
+    data[tags] = newTags;
+
+    table.cell(rowIndex, puzzle_name).invalidate();
+    table.cell(rowIndex, url).invalidate();
+    table.cell(rowIndex, is_meta).invalidate();
+    table.cell(rowIndex, tags).invalidate();
+
+    $.ajax(ajaxUrl, {
+        'method': 'POST',
+        'data': $(this).serialize(),
+        'success': function() {
+            showMessage(`Updated puzzle '${newPuzzleName}'`);
+            reload();
+        },
+        'error': function(response) {
+            showMessage(`Encountered error updating puzzle '${newPuzzleName}': ` +
+                `${response['responseJSON']['error']}`, 'error');
+            reload();
+        },
+    });
+
+    $('#editpuzzle').modal('hide');
+});
 </script>

--- a/puzzles/templates/modals/edit_puzzle.html
+++ b/puzzles/templates/modals/edit_puzzle.html
@@ -33,12 +33,12 @@
 <script type="text/javascript">
 function editPuzzleHandler() {
     var pk = $(this).data("pk");
-    var name = $(this).data("name");
+    var puzzleName = $(this).data("name");
     var url = $(this).data("url");
     var is_meta = $(this).data("is_meta");
     $('#edit-puzzle').attr('action', `/puzzles/edit/${pk}/`);
-    $('#id_name').attr('value', name);
-    $('#id_url').attr('value', url);
+    $('#id_name').val(puzzleName);
+    $('#id_url').val(url);
     if (is_meta) {
         $('#id_is_meta').attr('checked', 'checked');
     } else {

--- a/puzzles/templates/modals/submit_answer.html
+++ b/puzzles/templates/modals/submit_answer.html
@@ -35,7 +35,7 @@ function submitAnswerHandler(e) {
     // Need to set focus after delay to accommodate fade in
     setTimeout(function() {
         $('#guess-input').focus();
-    }, 350);
+    }, 500);
 }
 $('#puzzles').on('click', '.submitanswer', submitAnswerHandler);
 

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -183,22 +183,24 @@ def set_metas(request, pk):
 @transaction.atomic
 def edit_puzzle(request, pk):
     form = PuzzleForm(request.POST, auto_id=False)
-    if form.is_valid():
-        new_name = form.cleaned_data["name"]
-        new_url = url_normalize(form.cleaned_data["url"])
-        new_is_meta = form.cleaned_data["is_meta"]
-        puzzle = get_object_or_404(Puzzle.objects.select_for_update(), pk=pk)
-        try:
-            puzzle.update_metadata(new_name, new_url, new_is_meta)
-            # TODO(asdfryan): Consider also renaming the slack channel to match the
-            # new puzzle name.
-            metas = puzzle.metas.all()
-            for meta in metas:
-                GoogleApiClient.update_meta_sheet_feeders(meta)
-        except (DuplicatePuzzleNameError, DuplicatePuzzleUrlError, InvalidMetaPuzzleError) as e:
-           messages.error(request, str(e))
+    if not form.is_valid():
+        return JsonResponse({'error': 'Invalid edit puzzle form'}, status=400)
 
-    return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+    new_name = form.cleaned_data["name"]
+    new_url = url_normalize(form.cleaned_data["url"])
+    new_is_meta = form.cleaned_data["is_meta"]
+    puzzle = get_object_or_404(Puzzle.objects.select_for_update(), pk=pk)
+    try:
+        puzzle.update_metadata(new_name, new_url, new_is_meta)
+        # TODO(asdfryan): Consider also renaming the slack channel to match the
+        # new puzzle name.
+        metas = puzzle.metas.all()
+        for meta in metas:
+            GoogleApiClient.update_meta_sheet_feeders(meta)
+    except (DuplicatePuzzleNameError, DuplicatePuzzleUrlError, InvalidMetaPuzzleError) as e:
+       return JsonResponse({'error': str(e)}, status=400)
+
+    return JsonResponse({})
 
 
 @require_POST


### PR DESCRIPTION
Example success message when puzzle 'Anger' was renamed to 'Angering':

![anger-to-angering](https://user-images.githubusercontent.com/544734/72395572-ef75e080-3707-11ea-9e9c-96fdb83b81a4.png)
