### PR TITLE
Support deleting puzzle without page reload

### DIFF
--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -99,9 +99,11 @@ function areArraysEqual(arr1, arr2) {
 }
 
 function redrawTable(newdata) {
-    table.clear();
-    for (const row of newdata) {
-        table.row.add(row);
+    if (newdata) {
+        table.clear();
+        for (const row of newdata) {
+            table.row.add(row);
+        }
     }
     // keep current page position after redraw
     table.draw('full-hold');

--- a/puzzles/templates/modals/delete_puzzle.html
+++ b/puzzles/templates/modals/delete_puzzle.html
@@ -7,7 +7,7 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <form method="post" action="/puzzles/delete/">
+            <form id='delete-puzzle' method="post" action="/puzzles/delete/">
                 {% csrf_token %}
                 <div class="modal-body">
                     Are you sure you want to delete this puzzle?
@@ -24,10 +24,39 @@
 <script type="text/javascript">
 function deletePuzzleHandler() {
     var pk = $(this).data("pk");
-    var name = $(this).data("name");
+    var puzzleName = $(this).data("name");
     $('#deletepuzzle form').attr('action', `/puzzles/delete/${pk}/`);
-    $('#deletetitle').text(`Delete ${name}`);
+    $('#deletetitle').text(`Delete ${puzzleName}`);
+    $('#delete-puzzle').data('pk', pk);
 }
 
 $('#puzzles').on('click', '.deletepuzzle', deletePuzzleHandler);
+
+$('#delete-puzzle').on('submit', function(e) {
+    e.preventDefault();
+
+    let pk = $(this).data('pk');
+    let url = $(this).attr('action');
+    let row = table.row(`#puzzle-${pk}`);
+    let puzzleName = row.data()[puzzle_name];
+
+    row.remove();
+    redrawTable();
+
+    $.ajax(url, {
+        'method': 'POST',
+        'data': $(this).serialize(),
+        'success': function() {
+            showMessage(`Deleted puzzle '${puzzleName}'`);
+            reload();
+        },
+        'error': function(response) {
+            showMessage(`Encountered error deleting puzzle '${puzzleName}': ` +
+                `${response['responseJSON']['error']}`, 'error');
+            reload();
+        },
+    });
+
+    $('#deletepuzzle').modal('hide');
+});
 </script>

--- a/puzzles/views.py
+++ b/puzzles/views.py
@@ -207,9 +207,9 @@ def edit_puzzle(request, pk):
 def delete_puzzle(request, pk):
     puzzle = get_object_or_404(Puzzle.objects.select_for_update(), pk=pk)
     if puzzle.is_meta and Puzzle.objects.filter(metas__id=pk):
-        messages.error(request,
-            "Metapuzzles can only be deleted or made non-meta if no "
-            "other puzzles are assigned to it.")
+        return JsonResponse(
+            {'error': "Metapuzzles can only be deleted or made non-meta if no "
+                      "other puzzles are assigned to it."}, status=400)
     else:
         metas = list(puzzle.metas.all())
         puzzle.delete()
@@ -217,7 +217,7 @@ def delete_puzzle(request, pk):
         for meta in metas:
             GoogleApiClient.update_meta_sheet_feeders(meta)
 
-    return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/'))
+    return JsonResponse({})
 
 
 @require_POST


### PR DESCRIPTION
Example message when deleting a puzzle 'test':

![deleted-puzzle](https://user-images.githubusercontent.com/544734/72397736-b3924980-370e-11ea-8707-177afa08bc56.png)
