### PR TITLE
Support adding new puzzle without page reload

### DIFF
--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -39,7 +39,7 @@
                 </div>
                 <div class="modal-footer">
                     <button id='add-puzzle-cancel' type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button id='submit-add-puzzle' type="submit" class="btn btn-primary" name="submit" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Creating Puzzle">Add</button>
+                    <button id='submit-add-puzzle' type="submit" class="btn btn-primary" name="submit">Add</button>
                 </div>
             </form>
         </div>
@@ -90,10 +90,11 @@ $('#add-puzzle').on('submit', function(e) {
         'data': form.serialize(),
         'success': function(response) {
             let data = response['data'];
-            showMessage(`Added puzzle ${data[puzzle_name]}`);
             let newdata = Array.from(table.data());
             newdata.unshift(data);
             redrawTable(newdata);
+
+            showMessage(`Added puzzle ${data[puzzle_name]}`);
             closeAndResetAddPuzzleForm();
         },
         'error': function(response) {

--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -4,7 +4,7 @@
 
 <div class="d-flex justify-content-between px-3 pb-3">
     <h1>{{ hunt_name }} - All Puzzles</h1>
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addpuzzle">
+    <button id='add-new-puzzle' type="button" class="btn btn-primary" data-toggle="modal" data-target="#addpuzzle">
         Add New Puzzle
     </button>
 </div>
@@ -19,11 +19,11 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="addtitle">Add Puzzle</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <button id='add-puzzle-close' type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <form action="/hunts/{{ hunt_pk }}/" method="post" onsubmit="return disableSubmit(this);">
+            <form id='add-puzzle' action="/hunts/{{ hunt_pk }}/" method="post">
                 {% csrf_token %}
                 <div class="modal-body">
                     <div class="form-group">
@@ -38,8 +38,8 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-primary" name="submit">Add</button>
+                    <button id='add-puzzle-cancel' type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <button id='submit-add-puzzle' type="submit" class="btn btn-primary" name="submit" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Creating Puzzle">Add</button>
                 </div>
             </form>
         </div>
@@ -47,6 +47,62 @@
 </div>
 
 <script type="text/javascript">
+$('#add-new-puzzle').on('click', function() {
+    $('#add-puzzle-cancel').prop('disabled', false);
+    $('#submit-add-puzzle').prop('disabled', false);
+    $('#add-puzzle-close').show();
+    $('#submit-add-puzzle').html('Add');
+});
+
+function freezeModal(e) {
+    e.preventDefault();
+
+    setTimeout(function() {
+        $('#addpuzzle').off('hide.bs.modal', freezeModal);
+    }, 2000);
+}
+
+function closeAndResetAddPuzzleForm() {
+    $('#addpuzzle').off('hide.bs.modal', freezeModal);
+    $('#addpuzzle').modal('hide');
+    $(':input', '#addpuzzle').not(':button :hidden').val('')
+        .prop('checked', false);
+}
+
+$('#add-puzzle').on('submit', function(e) {
+    e.preventDefault();
+    $('#submit-add-puzzle').html("<i class='fa fa-spinner fa-spin fa-fw' aria-hidden='true'></i> Creating puzzle");
+
+    $('#add-puzzle-cancel').prop('disabled', true);
+    $('#submit-add-puzzle').prop('disabled', true);
+    $('#add-puzzle-close').hide();
+    $('#addpuzzle').on('hide.bs.modal', freezeModal);
+
+    let form = $(this);
+    let ajaxUrl = form.attr('action');
+    let values = {};
+    $.each(form.serializeArray(), function(i, field) {
+        values[field.name] = field.value;
+    });
+
+    $.ajax(ajaxUrl, {
+        'method': 'POST',
+        'data': form.serialize(),
+        'success': function(response) {
+            let data = response['data'];
+            showMessage(`Added puzzle ${data[puzzle_name]}`);
+            let newdata = Array.from(table.data());
+            newdata.unshift(data);
+            redrawTable(newdata);
+            closeAndResetAddPuzzleForm();
+        },
+        'error': function(response) {
+            showMessage(`Encountered error adding new puzzle: ${response['responseJSON']['error']}`, 'error');
+            closeAndResetAddPuzzleForm();
+        },
+    });
+});
+
 var slack_base_url = '{{ slack_base_url }}';
 var table;
 

--- a/hunts/templates/all_puzzles.html
+++ b/hunts/templates/all_puzzles.html
@@ -56,10 +56,6 @@ $('#add-new-puzzle').on('click', function() {
 
 function freezeModal(e) {
     e.preventDefault();
-
-    setTimeout(function() {
-        $('#addpuzzle').off('hide.bs.modal', freezeModal);
-    }, 2000);
 }
 
 function closeAndResetAddPuzzleForm() {


### PR DESCRIPTION
Filling out the form: note X button, Cancel, and Add are all present and clickable

![filling-out-form](https://user-images.githubusercontent.com/544734/72534911-a3c95100-3845-11ea-8fb0-b043ace640f0.png)

On form submit: X button is removed, Cancel is grayed out, Add changes to "<spinning wheel> Creating puzzle"
![creating-puzzle](https://user-images.githubusercontent.com/544734/72534961-b9d71180-3845-11ea-997b-7b07d5cfc27b.png)

On success:
![puzzle-added](https://user-images.githubusercontent.com/544734/72534970-be032f00-3845-11ea-9205-e9ede480647f.png)

On error:
![error-exists](https://user-images.githubusercontent.com/544734/72534986-c0658900-3845-11ea-9c12-3fd7674abfa9.png)
