### PR TITLE
Add pre-commit github actions workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
Automatically checks pre-commit linters on pull requests and commits to
the master branch. This actually enforces the pre-commit changes added
in https://github.com/cardinalitypuzzles/smallboard/pull/198.

See https://github.com/pre-commit/action for docs on the action used here.