### PR TITLE
Add HTTPS redirect support for production

### DIFF
--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -42,6 +42,10 @@ ALLOWED_HOSTS = [
     "smallboard.herokuapp.com",
 ]
 
+# This should be turned on in production to redirect HTTP to HTTPS
+# The development web server doesn't support HTTPS, however, so do not
+# turn this on in dev.
+SECURE_SSL_REDIRECT = os.environ.get("SECURE_SSL_REDIRECT")
 
 # Application definition
 


### PR DESCRIPTION
Force people to use HTTPS in prod (right now both work).

I already updated the config var in Heroku but we also need to update the python side.