### PR TITLE
Rename pre-commit workflow to pre-submit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,6 +2,7 @@ name: pre-commit
 
 on:
   pull_request:
+    branches: [master]
   push:
     branches: [master]
 
@@ -18,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.x'
+          python-version: "3.8.x"
 
       - name: Install python deps
         run: |

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -1,4 +1,4 @@
-name: pre-commit
+name: pre-submit
 
 on:
   pull_request:

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -2,7 +2,6 @@ name: pre-submit
 
 on:
   pull_request:
-    branches: [master]
   push:
     branches: [master]
 
@@ -19,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8.x"
+          python-version: '3.8.x'
 
       - name: Install python deps
         run: |


### PR DESCRIPTION
~~This relaxes the requirements for merging PRs to other PRs or non-master branches.

@pcvera since you're authoring PRs targeting @rgossiaux's PR for the react rewrite, I figure we shouldn't block the changes on presubmit checks until it's time to merge the whole thing into master (a.k.a. the main branch).~~

@erwa pointed out that we can still leave these presubmits to run on any PR without blocking merging as long as we don't merge into the master (protected) branch. In that case, this PR just renames the workflow as a cleanup.