### PR TITLE
Clean up pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: check-added-large-files
       - id: check-docstring-first
       - id: check-merge-conflict
+        args: [--assume-in-merge] # Always run this check, not just during git merge.
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
     rev: 20.8b1


### PR DESCRIPTION
- always run check-merge-conflict
- remove requirements.txt fixer (since we don't use that file anymore)