### PR TITLE
[React] Add API/UI for editing puzzles and changing puzzle status

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,6 +15,30 @@ class PuzzleSerializer(serializers.ModelSerializer):
     def get_tags(self, obj):
         return [{"name": tag.name, "color": tag.color} for tag in obj.tags.all()]
 
+    def validate(self, data, *args, **kwargs):
+        # The django rest framework validation is super clunky for validating
+        # partial updates; we need to merge new values with existing ones
+        # ourselves annoyingly.
+        def get_merged(attr):
+            if attr in data:
+                return data[attr]
+            if self.instance and hasattr(self.instance, attr):
+                return getattr(self.instance, attr)
+            return None
+
+        # Feeders can't have feeders
+        if not get_merged("is_meta") and len(self.instance.feeders.all()) > 0:
+            raise serializers.ValidationError(
+                "Puzzle must be a meta to have puzzles assigned."
+            )
+        # Answers mean solves
+        if get_merged("status") == "SOLVED" and not get_merged("answer"):
+            raise serializers.ValidationError("Solved puzzles must have answers.")
+        if get_merged("answer") and get_merged("status") != "SOLVED":
+            raise serializers.ValidationError("Puzzles with answers are solved.")
+
+        return data
+
     class Meta:
         model = Puzzle
         fields = (
@@ -30,4 +54,14 @@ class PuzzleSerializer(serializers.ModelSerializer):
             "metas",
             "feeders",
             "is_meta",
+        )
+
+        read_only_fields = (
+            "id",
+            "hunt_id",
+            "sheet",
+            "answer",
+            "tags",
+            "metas",
+            "feeders",
         )

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,6 +11,7 @@ puzzle_detail = views.PuzzleViewSet.as_view(
     {
         "get": "retrieve",
         "delete": "destroy",
+        "patch": "partial_update",
     }
 )
 

--- a/api/views.py
+++ b/api/views.py
@@ -50,3 +50,16 @@ class PuzzleViewSet(viewsets.ModelViewSet):
             puzzle.delete()
 
         return Response({})
+
+    def partial_update(self, request, pk=None, **kwargs):
+        puzzle = None
+        with transaction.atomic():
+            puzzle = self.get_object()
+            serializer = self.get_serializer(puzzle, data=request.data, partial=True)
+            serializer.is_valid(raise_exception=True)
+            data = serializer.validated_data
+            puzzle.update_metadata(
+                new_name=data["name"], new_url=data["url"], new_is_meta=data["is_meta"]
+            )
+
+        return Response(PuzzleSerializer(puzzle).data)

--- a/api/views.py
+++ b/api/views.py
@@ -59,7 +59,12 @@ class PuzzleViewSet(viewsets.ModelViewSet):
             serializer.is_valid(raise_exception=True)
             data = serializer.validated_data
             puzzle.update_metadata(
-                new_name=data["name"], new_url=data["url"], new_is_meta=data["is_meta"]
+                new_name=data.get("name", puzzle.name),
+                new_url=data.get("url", puzzle.url),
+                new_is_meta=data.get("is_meta", puzzle.is_meta),
             )
+            if "status" in data:
+                puzzle.status = data["status"]
+                puzzle.save()
 
         return Response(PuzzleSerializer(puzzle).data)

--- a/hunts/src/EditPuzzleModal.js
+++ b/hunts/src/EditPuzzleModal.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import { updatePuzzle } from "./puzzlesSlice";
+import { hideModal } from "./modalSlice";
+
+function EditPuzzleModal({ huntId, puzzleId, name, url, isMeta }) {
+  const [newName, setNewName] = React.useState(name);
+  const [newUrl, setNewUrl] = React.useState(url);
+  const [newIsMeta, setNewIsMeta] = React.useState(isMeta);
+  const dispatch = useDispatch();
+  const onSubmit = () => {
+    dispatch(
+      updatePuzzle({
+        huntId,
+        id: puzzleId,
+        body: { name: newName, url: newUrl, is_meta: newIsMeta },
+      })
+    ).finally(() => {
+      dispatch(hideModal());
+    });
+  };
+  return (
+    <>
+      <Modal.Header closeButton>
+        <Modal.Title>Edit Puzzle</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form>
+          <Form.Group controlId="editPuzzle.name">
+            <Form.Label>Puzzle name</Form.Label>
+            <Form.Control
+              placeholder="Name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+          </Form.Group>
+          <Form.Group controlId="editPuzzle.url">
+            <Form.Label>Puzzle url</Form.Label>
+            <Form.Control
+              placeholder="https://www.example.com/"
+              value={newUrl}
+              onChange={(e) => setNewUrl(e.target.value)}
+            />
+          </Form.Group>
+          <Form.Check
+            type="checkbox"
+            label="Is meta"
+            checked={newIsMeta}
+            onChange={(e) => setNewIsMeta(e.target.checked)}
+          />
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={() => dispatch(hideModal())}>
+          Cancel
+        </Button>
+        <Button variant="primary" onClick={onSubmit}>
+          Submit
+        </Button>
+      </Modal.Footer>
+    </>
+  );
+}
+
+export default EditPuzzleModal;

--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -7,6 +7,7 @@ import { hideModal } from "./modalSlice";
 import { PuzzleTable } from "./puzzle-table";
 import NameCell from "./NameCell";
 import DeletePuzzleModal from "./DeletePuzzleModal";
+import EditPuzzleModal from "./EditPuzzleModal";
 import useInterval from "@use-it/interval";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
@@ -18,6 +19,7 @@ import { faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
 
 const MODAL_COMPONENTS = {
   DELETE_PUZZLE: DeletePuzzleModal,
+  EDIT_PUZZLE: EditPuzzleModal,
 };
 
 const TABLE_COLUMNS = [

--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -6,6 +6,7 @@ import { fetchHunt } from "./huntSlice";
 import { hideModal } from "./modalSlice";
 import { PuzzleTable } from "./puzzle-table";
 import NameCell from "./NameCell";
+import StatusCell from "./StatusCell";
 import DeletePuzzleModal from "./DeletePuzzleModal";
 import EditPuzzleModal from "./EditPuzzleModal";
 import useInterval from "@use-it/interval";
@@ -41,20 +42,7 @@ const TABLE_COLUMNS = [
   {
     Header: "Status",
     accessor: "status",
-    Cell: ({ row, value }) =>
-      ["SOLVING", "STUCK", "EXTRACTION"].includes(value) ? (
-        <DropdownButton
-          id={`status-dropdown-${row.id}`}
-          title={value}
-          variant="outline-primary"
-        >
-          <Dropdown.Item>SOLVING</Dropdown.Item>
-          <Dropdown.Item>STUCK</Dropdown.Item>
-          <Dropdown.Item>EXTRACTION</Dropdown.Item>
-        </DropdownButton>
-      ) : (
-        value
-      ),
+    Cell: StatusCell,
   },
   {
     Header: "Puzzle",

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -4,7 +4,6 @@ import Button from "react-bootstrap/Button";
 import { useSelector, useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEdit, faTrashAlt } from "@fortawesome/free-regular-svg-icons";
-import { deletePuzzle } from "./puzzlesSlice";
 import { showModal } from "./modalSlice";
 
 export default function NameCell({ row, value }) {
@@ -28,7 +27,23 @@ export default function NameCell({ row, value }) {
         </span>
       )}{" "}
       {row.values.is_meta ? <Badge variant="dark">META</Badge> : null}
-      <span style={{ cursor: "pointer" }}>
+      <span
+        style={{ cursor: "pointer" }}
+        onClick={() =>
+          dispatch(
+            showModal({
+              type: "EDIT_PUZZLE",
+              props: {
+                huntId,
+                puzzleId: row.values.id,
+                name: row.values.name,
+                url: row.values.url,
+                isMeta: row.values.is_meta,
+              },
+            })
+          )
+        }
+      >
         <Badge pill variant="light">
           <FontAwesomeIcon icon={faEdit} />
         </Badge>

--- a/hunts/src/StatusCell.js
+++ b/hunts/src/StatusCell.js
@@ -1,0 +1,34 @@
+import React from "react";
+import DropdownButton from "react-bootstrap/DropdownButton";
+import Dropdown from "react-bootstrap/Dropdown";
+import { useSelector, useDispatch } from "react-redux";
+import { updatePuzzle } from "./puzzlesSlice";
+
+export default function StatusCell({ row, value }) {
+  const { id: huntId } = useSelector((state) => state.hunt);
+  const dispatch = useDispatch();
+  if (["SOLVING", "STUCK", "EXTRACTION"].includes(value)) {
+    return (
+      <DropdownButton
+        id={`status-dropdown-${row.id}`}
+        title={value}
+        variant="outline-primary"
+        onSelect={(status) => {
+          dispatch(
+            updatePuzzle({
+              huntId,
+              id: row.values.id,
+              body: { status },
+            })
+          );
+        }}
+      >
+        <Dropdown.Item eventKey="SOLVING">SOLVING</Dropdown.Item>
+        <Dropdown.Item eventKey="STUCK">STUCK</Dropdown.Item>
+        <Dropdown.Item eventKey="EXTRACTION">EXTRACTION</Dropdown.Item>
+      </DropdownButton>
+    );
+  } else {
+    return value;
+  }
+}

--- a/hunts/src/api.js
+++ b/hunts/src/api.js
@@ -25,6 +25,24 @@ function deletePuzzle(huntId, puzzleId) {
   });
 }
 
+function updatePuzzle(huntId, puzzleId, data) {
+  const puzzleApiUrl = `/api/v1/hunt/${huntId}/puzzles/${puzzleId}`;
+  return fetch(puzzleApiUrl, {
+    method: "PATCH",
+    headers: {
+      "X-CSRFToken": Cookies.get("csrftoken"),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  }).then((response) => {
+    if (response.status > 400) {
+      // TODO: error handling
+      console.error("Update puzzle API failure", response);
+    }
+    return response.json();
+  });
+}
+
 function getHunt(huntId) {
   const huntApiUrl = `/api/v1/hunt/${huntId}`;
   return fetch(huntApiUrl).then((response) => {
@@ -36,4 +54,4 @@ function getHunt(huntId) {
   });
 }
 
-export default { getHunt, getPuzzles, deletePuzzle };
+export default { getHunt, getPuzzles, deletePuzzle, updatePuzzle };

--- a/hunts/src/puzzlesSlice.js
+++ b/hunts/src/puzzlesSlice.js
@@ -22,6 +22,14 @@ export const fetchPuzzles = createAsyncThunk(
   }
 );
 
+export const updatePuzzle = createAsyncThunk(
+  "puzzles/updatePuzzle",
+  async ({ huntId, id, body }) => {
+    const response = await api.updatePuzzle(huntId, id, body);
+    return response;
+  }
+);
+
 function puzzleComparator(a, b) {
   // Solved puzzles should appear below unsolved ones
   if (a.status == "SOLVED" && b.status != "SOLVED") {
@@ -54,6 +62,12 @@ export const puzzlesSlice = createSlice({
     },
     [fetchPuzzles.fulfilled]: (state, action) => {
       puzzlesAdapter.setAll(state, action.payload);
+    },
+    [updatePuzzle.fulfilled]: (state, action) => {
+      puzzlesAdapter.updateOne(state, {
+        id: action.payload.id,
+        changes: { ...action.payload },
+      });
     },
   },
 });


### PR DESCRIPTION
They're implemented separately in the commit history to view them separately. Once the API to edit a puzzle is in place, changing puzzle status (only between solving/stuck/extraction) is nearly free fortunately.

For #251; depends on #256 and transitively on #253.