### PR TITLE
Handle the no-discord-API-token case

### DIFF
--- a/hunts/views.py
+++ b/hunts/views.py
@@ -173,7 +173,7 @@ class HuntView(LoginRequiredMixin, View):
             if google_api_client:
                 google_api_client.add_puzzle_link_to_sheet(puzzle_url, sheet)
 
-            if settings.CHAT_DEFAULT_SERVICE is not None:
+            if settings.CHAT_DEFAULT_SERVICE:
                 chat_room = ChatRoom.objects.create(
                     service=settings.CHAT_DEFAULT_SERVICE, name=name
                 )

--- a/hunts/views.py
+++ b/hunts/views.py
@@ -173,10 +173,14 @@ class HuntView(LoginRequiredMixin, View):
             if google_api_client:
                 google_api_client.add_puzzle_link_to_sheet(puzzle_url, sheet)
 
-            chat_room = ChatRoom.objects.create(
-                service=settings.CHAT_DEFAULT_SERVICE, name=name
-            )
-            chat_room.create_channels()
+            if settings.CHAT_DEFAULT_SERVICE is not None:
+                chat_room = ChatRoom.objects.create(
+                    service=settings.CHAT_DEFAULT_SERVICE, name=name
+                )
+                chat_room.create_channels()
+            else:
+                logger.warn("Chat room not created for puzzle %s" % name)
+                chat_room = None
 
             try:
                 puzzle = Puzzle.objects.create(

--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -251,7 +251,14 @@ TAGGIT_TAGS_FROM_STRING = "puzzles.tag_utils.to_tag"
 
 import discord_lib
 
-CHAT_DEFAULT_SERVICE = "DISCORD"
-CHAT_SERVICES = {
-    "DISCORD": discord_lib.DiscordChatService,
-}
+if not "DISCORD_API_TOKEN" in os.environ:
+    logger.warn(
+        "No Discord API token found in environment. Automatic Discord channel creation disabled."
+    )
+    CHAT_DEFAULT_SERVICE = None
+    CHAT_SERVICES = {}
+else:
+    CHAT_DEFAULT_SERVICE = "DISCORD"
+    CHAT_SERVICES = {
+        "DISCORD": discord_lib.DiscordChatService,
+    }


### PR DESCRIPTION
What it says. I haven't added tests or checked very hard that this doesn't break other stuff and honestly what I did seemed a bit too simple.

Just to be clear, this PR is meant to, if no discord API token is in config, just not create discord channels (but otherwise do the same things).