### PR TITLE
Fix windows line ending issue with Docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+patches/*.patch text eol=lf


### PR DESCRIPTION
Git on windows automatically converts line endings to CRLF on checkout,
which makes these patch files not readable inside Docker. This should
(hopefully) exclude the patch files from this and fix the problem on
Windows though since I don't have a Windows machine I haven't actually
tested it.