### PR TITLE
Remove Assign Meta column

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -86,9 +86,9 @@ class ChatRoomSerializer(serializers.ModelSerializer):
 class PuzzleTagSerializer(serializers.ModelSerializer):
     class Meta:
         model = PuzzleTag
-        fields = ("id", "name", "color")
+        fields = ("id", "name", "color", "is_meta")
 
-        read_only_fields = ("id",)
+        read_only_fields = ("id", "is_meta")
 
 
 class PuzzleSerializer(serializers.ModelSerializer):

--- a/hunts/src/EditPuzzleTagsModal.js
+++ b/hunts/src/EditPuzzleTagsModal.js
@@ -30,25 +30,50 @@ function EditPuzzleTagsModal({ huntId, puzzleId }) {
       </Modal.Header>
       <Modal.Body>
         <p>
-          All tags:{" "}
-          {allTags.map((tag) => (
-            <TagPill
-              {...tag}
-              puzzleId={puzzleId}
-              editable={false}
-              key={tag.name}
-              style={{ cursor: "pointer" }}
-              onClick={() =>
-                dispatch(
-                  addPuzzleTag({
-                    ...tag,
-                    huntId,
-                    puzzleId,
-                  })
-                )
-              }
-            />
-          ))}
+          Add metas:
+          {allTags
+            .filter((tag) => tag.is_meta)
+            .map((tag) => (
+              <TagPill
+                {...tag}
+                puzzleId={puzzleId}
+                editable={false}
+                key={tag.name}
+                style={{ cursor: "pointer" }}
+                onClick={() =>
+                  dispatch(
+                    addPuzzleTag({
+                      ...tag,
+                      huntId,
+                      puzzleId,
+                    })
+                  )
+                }
+              />
+            ))}
+        </p>
+        <p>
+          Add tags:{" "}
+          {allTags
+            .filter((tag) => !tag.is_meta)
+            .map((tag) => (
+              <TagPill
+                {...tag}
+                puzzleId={puzzleId}
+                editable={false}
+                key={tag.name}
+                style={{ cursor: "pointer" }}
+                onClick={() =>
+                  dispatch(
+                    addPuzzleTag({
+                      ...tag,
+                      huntId,
+                      puzzleId,
+                    })
+                  )
+                }
+              />
+            ))}
         </p>
         <Form
           onSubmit={(e) => {

--- a/hunts/src/EditPuzzleTagsModal.js
+++ b/hunts/src/EditPuzzleTagsModal.js
@@ -39,7 +39,6 @@ function EditPuzzleTagsModal({ huntId, puzzleId }) {
                 puzzleId={puzzleId}
                 editable={false}
                 key={tag.name}
-                style={{ cursor: "pointer" }}
                 onClick={() =>
                   dispatch(
                     addPuzzleTag({
@@ -62,7 +61,6 @@ function EditPuzzleTagsModal({ huntId, puzzleId }) {
                 puzzleId={puzzleId}
                 editable={false}
                 key={tag.name}
-                style={{ cursor: "pointer" }}
                 onClick={() =>
                   dispatch(
                     addPuzzleTag({

--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -92,13 +92,6 @@ const TABLE_COLUMNS = [
     Cell: TagCell,
   },
   {
-    Header: "Metas",
-    id: "metas",
-    Cell: ({ row, value }) => (
-      <Button variant="outline-secondary">Assign Meta</Button>
-    ),
-  },
-  {
     accessor: "is_meta",
     id: "is_meta",
   },

--- a/hunts/src/TagPill.js
+++ b/hunts/src/TagPill.js
@@ -15,8 +15,12 @@ function TagPill({
 }) {
   const { id: huntId } = useSelector((state) => state.hunt);
   const dispatch = useDispatch();
+  const style = {};
+  if (onClick !== null) {
+    style.cursor = "pointer";
+  }
   return (
-    <Badge pill variant={color} key={name} onClick={onClick}>
+    <Badge pill variant={color} key={name} onClick={onClick} style={style}>
       {name}
       {editable ? (
         <span


### PR DESCRIPTION
Since adding/removing tags also handles meta assignment, this column is
a little redundant. Removing it makes the table less busy and unifies
the UI a bit by having everything go through tags.