### PR TITLE
React: Include default tags in add tag modal

### DIFF
--- a/hunts/src/constants.js
+++ b/hunts/src/constants.js
@@ -4,3 +4,14 @@ export const SELECTABLE_TAG_COLORS = [
   { color: "secondary", display: "Gray" },
   { color: "light", display: "White" },
 ];
+// TODO: Store these in the backend and read them from an API call
+export const DEFAULT_TAGS = [
+  { name: "HIGH PRIORITY", color: "danger" },
+  { name: "LOW PRIORITY", color: "warning" },
+  { name: "BACKSOLVED", color: "success" },
+  { name: "WORD", color: "light" },
+  { name: "LOGIC", color: "light" },
+  { name: "TECHNICAL", color: "light" },
+  { name: "SLOG", color: "secondary" },
+  { name: "INTERACTIVE", color: "primary" },
+];

--- a/hunts/src/puzzlesSlice.js
+++ b/hunts/src/puzzlesSlice.js
@@ -5,6 +5,7 @@ import {
   createEntityAdapter,
 } from "@reduxjs/toolkit";
 import api from "./api";
+import { DEFAULT_TAGS } from "./constants";
 
 export const addPuzzle = createAsyncThunk(
   "puzzles/addPuzzle",
@@ -203,13 +204,16 @@ export const selectPuzzleTableData = createSelector(
 export const selectAllTags = createSelector(
   [puzzlesSelectors.selectAll],
   (puzzles) => {
-    const tags = puzzles.map((puzzle) => puzzle.tags).flat();
-    const tagIds = new Set();
+    const tags = puzzles
+      .map((puzzle) => puzzle.tags)
+      .flat()
+      .concat(DEFAULT_TAGS);
+    const tagNames = new Set();
     const uniqueTags = tags.reduce(
       (uniqueTags, tag) =>
-        tagIds.has(tag.id)
+        tagNames.has(tag.name)
           ? uniqueTags
-          : tagIds.add(tag.id) && [...uniqueTags, tag],
+          : tagNames.add(tag.name) && [...uniqueTags, tag],
       []
     );
     uniqueTags.sort(


### PR DESCRIPTION
Fixes #286

This is a little hacky, I think. Ideally the API wouldn't let you create
tags with reserved colors. In that case the default tags need to exist
in python (passed down as part of the hunt info, probably)
and then the API validation needs to be updated.

Other things are higher pri than making this work elegantly though so
this is good enough for now.