### PR TITLE
Validate URLs as URLs in API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -96,7 +96,7 @@ class PuzzleSerializer(serializers.ModelSerializer):
     tags = serializers.SerializerMethodField(required=False)
     guesses = serializers.SerializerMethodField()
     # Have to specify this explicitly for validate_url to run
-    url = serializers.CharField()
+    url = serializers.URLField()
     hunt_id = serializers.PrimaryKeyRelatedField(
         read_only=True, default=CurrentHuntDefault()
     )


### PR DESCRIPTION
Now it will complain if you don't enter a full URL with protocol,
matching the old UI behavior. Without this change it doesn't care and
just normalizes whatever you input.