### PR TITLE
Fix bug related to discord channel deletion

### DIFF
--- a/discord_lib/discord_chat_service.py
+++ b/discord_lib/discord_chat_service.py
@@ -37,8 +37,9 @@ class DiscordChatService(ChatService):
 
     def delete_channel(self, channel_id):
         channels_by_id = self._client.guilds_channels_list(self._guild_id)
-        if channel_id in channels_by_id:
-            self._client.channels_delete(channels_by_id[channel_id])
+        # channel_id is a string, but the discord API returns/expects int.
+        if int(channel_id) in channels_by_id:
+            self._client.channels_delete(int(channel_id))
 
     def create_channel(self, name, chan_type=ChannelType.GUILD_TEXT, parent_name=None):
         parent_id = None

--- a/discord_lib/test.py
+++ b/discord_lib/test.py
@@ -116,7 +116,7 @@ class TestDiscordChatService(TestCase):
 
         self.mock_client.guilds_channels_list.return_value = {channel.id: channel}
         self.service.delete_text_channel(channel.id)
-        self.mock_client.channels_delete.assert_called_once_with(channel)
+        self.mock_client.channels_delete.assert_called_once_with(channel.id)
 
     def test_delete_audio_channel(self):
         name = "channel-name"
@@ -126,4 +126,4 @@ class TestDiscordChatService(TestCase):
 
         self.mock_client.guilds_channels_list.return_value = {channel.id: channel}
         self.service.delete_audio_channel(channel.id)
-        self.mock_client.channels_delete.assert_called_once_with(channel)
+        self.mock_client.channels_delete.assert_called_once_with(channel.id)


### PR DESCRIPTION
We store channel_id as string, but discord API returns/expects int.