### PR TITLE
Add section in dev-guide to setup .env

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        # allow changes to drop code coverage by at most this much
+        threshold: 0.1%

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,9 @@
 # Use sqlite if you don't want to install and set up a PostgreSQL database.
 DATABASE_URL=sqlite:///db.sqlite3
 #DATABASE_URL=postgres://myuser:mypass@localhost/test_smallboard
+
+# This is used for cryptographic stuff including managing sessions.
+# Set it to avoid having to relogin in each time you restart the service.
+# You can generate a random key by using
+# python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+DJANGO_SECRET_KEY=changeme

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,10 @@
+# DATABASE_URL only needs to be set if running locally without using Docker.
+# Our Docker setup already spins up a separate Postgres container and configures
+# the web container to connect to the Postgres container.
+# For local setup:
 # Uncomment exactly *one* of the following DATABASE_URL configs.
 # Use sqlite if you don't want to install and set up a PostgreSQL database.
-DATABASE_URL=sqlite:///db.sqlite3
+#DATABASE_URL=sqlite:///db.sqlite3
 #DATABASE_URL=postgres://myuser:mypass@localhost/test_smallboard
 
 # This is used for cryptographic stuff including managing sessions.

--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,7 @@
 # For local setup:
 # Uncomment exactly *one* of the following DATABASE_URL configs.
 # Use sqlite if you don't want to install and set up a PostgreSQL database.
-#DATABASE_URL=sqlite:///db.sqlite3
+DATABASE_URL=sqlite:///db.sqlite3
 #DATABASE_URL=postgres://myuser:mypass@localhost/test_smallboard
 
 # This is used for cryptographic stuff including managing sessions.

--- a/dev-guide.md
+++ b/dev-guide.md
@@ -34,7 +34,7 @@ Both Docker and manual setup read environment variables from an `.env` file. An 
 cp .env.test .env
 ```
 
-See below for more details on the `.env` file.
+See below for more details on the `.env` file. You probably want to set at least `DJANGO_SECRET_KEY` so that your session isn't invalidated each time you restart the web container.
 
 
 #### Docker setup

--- a/dev-guide.md
+++ b/dev-guide.md
@@ -16,8 +16,7 @@ To run Small Board manually, you will need:
 - Pipenv
 - [NodeJS](https://nodejs.org/en/download/package-manager/) (version 10 or later)
 - [Yarn](https://classic.yarnpkg.com/en/docs/install/)
-- # a local database (PostgreSQL or SQLite)
-- a local database (e.g.: Postgres)
+- a local database (e.g.: PostgreSQL or SQLite)
 
 #### Checking out the code
 
@@ -26,6 +25,17 @@ To check out the code, you first need to [install Git](https://git-scm.com/book/
 ```
 git clone git@github.com:cardinalitypuzzles/smallboard.git
 ```
+
+### Set up an `.env` file
+
+Both Docker and manual setup read environment variables from an `.env` file. An example `.env.test` file is provided, which you should copy to `.env`:
+
+```
+cp .env.test .env
+```
+
+See below for more details on the `.env` file.
+
 
 #### Docker setup
 


### PR DESCRIPTION
Added a reminder in dev-guide.md to set up `.env`, which is required by our Docker and manual setups.

```
$ docker-compose up
ERROR: Couldn't find env file: /home/erwaman/github/cardinalitypuzzles/smallboard/.env
```