### PR TITLE
Fix node_modules Docker issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,3 @@ RUN yarn install
 # Install patches
 COPY ./patches ./patches
 RUN yarn install
-
-COPY . .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/usr/src/smallboard/:Z
+      - /usr/src/smallboard/node_modules
     ports:
       - 8000:8000
     environment:


### PR DESCRIPTION
Fixes #313.

The node_modules/ directory generated in the image was getting bypassed
when we mounted the source code directory. Specifying it as another
volume somehow seems to fix this.

Also deleting the code copying line from the Dockerfile since it's
misleading and unnecessary with the volume.