### PR TITLE
Fix modals causing table rerenders

### DIFF
--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -38,7 +38,7 @@ function rowClassName(row) {
   }
 }
 
-export function PuzzleTable({ columns, data, filter }) {
+export const PuzzleTable = React.memo(({ columns, data, filter }) => {
   const filterTypes = React.useMemo(
     () => ({
       globalFilter: textFilterFn,
@@ -111,7 +111,7 @@ export function PuzzleTable({ columns, data, filter }) {
       </Table>
     </>
   );
-}
+});
 
 PuzzleTable.propTypes = {
   columns: PropTypes.array.isRequired,


### PR DESCRIPTION
Fixes #290

Opening/closing a modal re-renders the parent component; since the PuzzleTable
is a pure component we can wrap in React.memo and only rerender when
props (ie data) change.