### PR TITLE
transfer ownership of sheets after creation

### DIFF
--- a/google_api_lib/task.py
+++ b/google_api_lib/task.py
@@ -41,18 +41,6 @@ def create_google_sheets_helper(self, name):
     return file
 
 
-def transfer_ownership(self, file_id):
-    response = (
-        self._drive_service.permissions()
-        .create(
-            fileId=file_id,
-            body=req_body,
-            fields="webViewLink",
-        )
-        .execute()
-    )
-
-
 @shared_task(base=GoogleApiClientTask, bind=True)
 def create_google_sheets(self, puzzle_id, name, puzzle_url=None):
     response = create_google_sheets_helper(self, name)

--- a/google_api_lib/utils.py
+++ b/google_api_lib/utils.py
@@ -26,3 +26,10 @@ class GoogleApiClientTask(Task):
         self._sheets_service = googleapiclient.discovery.build(
             "sheets", "v4", credentials=self._credentials
         )
+
+        template = (
+            self._drive_service.files()
+            .get(fileId=settings.GOOGLE_SHEETS_TEMPLATE_FILE_ID, fields="owners")
+            .execute()
+        )
+        self._sheets_owner = template["owners"][0]["emailAddress"]


### PR DESCRIPTION
The scripts were broken (#169) because copying the sheets template sets the owner to a service account, which is unable to run scripts. This change transfers ownership back to original owner of template. 