### PR TITLE
Fix sheets 

### DIFF
--- a/google_api_lib/task.py
+++ b/google_api_lib/task.py
@@ -13,11 +13,13 @@ from puzzles.models import Puzzle
 logger = logging.getLogger(__name__)
 
 
+# helper function that can be mocked for testing
 def create_google_sheets_helper(self, name):
     req_body = {"name": name}
     # copy template sheet
     file = (
-        self._drive_service.files()
+        self.drive_service()
+        .files()
         .copy(
             fileId=settings.GOOGLE_SHEETS_TEMPLATE_FILE_ID,
             body=req_body,
@@ -36,7 +38,7 @@ def transfer_ownership(self, file_id):
         "role": "owner",
         "emailAddress": self._sheets_owner,
     }
-    self._drive_service.permissions().create(
+    self.drive_service().permissions().create(
         fileId=file_id,
         body=transfer_permission,
         transferOwnership=True,
@@ -72,7 +74,7 @@ def add_puzzle_link_to_sheet(self, puzzle_url, sheet_url):
             [f'=HYPERLINK("{puzzle_url}", "Puzzle Link")'],
         ]
     }
-    self._sheets_service.spreadsheets().values().update(
+    self.sheets_service().spreadsheets().values().update(
         spreadsheetId=extract_id_from_sheets_url(sheet_url),
         range="A1:B2",
         valueInputOption="USER_ENTERED",
@@ -113,7 +115,8 @@ def update_meta_sheet_feeders(self, puzzle_id):
     # Ref: https://github.com/googleapis/google-api-python-client/blob/master/docs/thread_safety.md
     http = _auth.authorized_http(self._credentials)
     response = (
-        self._sheets_service.spreadsheets()
+        self.sheets_service()
+        .spreadsheets()
         .get(
             spreadsheetId=spreadsheet_id,
             fields="sheets.properties.title,sheets.properties.sheetId",
@@ -138,7 +141,8 @@ def update_meta_sheet_feeders(self, puzzle_id):
         }
     )
     response = (
-        self._sheets_service.spreadsheets()
+        self.sheets_service()
+        .spreadsheets()
         .batchUpdate(
             spreadsheetId=spreadsheet_id,
             body={"requests": requests},
@@ -257,7 +261,7 @@ def update_meta_sheet_feeders(self, puzzle_id):
             },
         ]
     }
-    self._sheets_service.spreadsheets().batchUpdate(
+    self.sheets_service().spreadsheets().batchUpdate(
         spreadsheetId=spreadsheet_id, body=body
     ).execute(http=http)
     logger.info(

--- a/google_api_lib/tests.py
+++ b/google_api_lib/tests.py
@@ -8,7 +8,11 @@ TEST_SHEET = "testsheet.com"
 
 
 def mock_create_google_sheets_helper(self, name):
-    return {"webViewLink": TEST_SHEET}
+    return {"id": "0", "webViewLink": TEST_SHEET}
+
+
+def mock_transfer_ownership(file_id):
+    return
 
 
 def mock_add_puzzle_link_to_sheet(puzzle_url, sheet_url):
@@ -26,6 +30,10 @@ class TestGoogleSheets(TestCase):
     @patch(
         "google_api_lib.task.create_google_sheets_helper",
         mock_create_google_sheets_helper,
+    )
+    @patch(
+        "google_api_lib.task.transfer_ownership.delay",
+        mock_transfer_ownership,
     )
     @patch(
         "google_api_lib.task.add_puzzle_link_to_sheet", mock_add_puzzle_link_to_sheet

--- a/google_api_lib/tests.py
+++ b/google_api_lib/tests.py
@@ -11,7 +11,7 @@ def mock_create_google_sheets_helper(self, name):
     return {"id": "0", "webViewLink": TEST_SHEET}
 
 
-def mock_transfer_ownership(file_id):
+def mock_transfer_ownership(file):
     return
 
 

--- a/google_api_lib/whitelist.py
+++ b/google_api_lib/whitelist.py
@@ -5,7 +5,7 @@ from celery import shared_task
 @shared_task(base=GoogleApiClientTask, bind=True)
 def get_file_user_emails(self, file_id):
     response = (
-        self._drive_service.files().get(fileId=file_id, fields="permissions").execute()
+        self.drive_service().files().get(fileId=file_id, fields="permissions").execute()
     )
 
     permissions = response["permissions"]


### PR DESCRIPTION
A few changes for #327 that hopefully makes sheets creation more robust:

- Separates sheets creation and transferring of sheets ownership from service account to user account. The latter was failing due to a sharingRateLimitExceeded error, which according to [this stackoverflow](https://stackoverflow.com/questions/46844246/drive-api-sharingratelimitexceeded-error) is because there is a 50 permission creation per day, although I couldn't find this quota in the official google API docs. 
- Switch from permission creation to permission update, which for some reason is not quota-ed. I wrote a script to update the permissions for the hundreds of existing sheets and I didn't see that error again, so hopefully that means this will not break mid-hunt. Even if it does break, creation and ownership are separate now, so we'll at least have sheets even if the custom functions won't work, which is not the best but not so bad.
- Add auto retries with backoff
