### PR TITLE
more workers, more queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,8 @@
 release: python manage.py migrate --noinput
 web: gunicorn smallboard.wsgi --log-file -
+
+cgs_worker1: celery -A smallboard worker -l INFO -Q cgs_queue
+cgs_worker2: celery -A smallboard worker -l INFO -Q cgs_queue
+cgs_worker3: celery -A smallboard worker -l INFO -Q cgs_queue
+
 worker: celery -A smallboard worker -l INFO

--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -258,7 +258,12 @@ else:
 
 
 # Celery settings
+
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_TASK_TIME_LIMIT = 60
 CELERY_TASK_TRACK_STARTED = True
 CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://")
+
+CELERY_TASK_ROUTES = {
+    "google_api_lib.task.create_google_sheets": {"queue": "cgs_queue"}
+}


### PR DESCRIPTION
As mentioned in #329:

> Not directly, but somewhat related: currently we just have a single worker for all the celery google related tasks. This is so I could avoid thinking about what would happen if multiple workers edited a sheet. But it'd be sorta bad if our poor single worker died midhunt (idk how likely this is)
>
> I'm thinking of adding a celery queue for sheet creation that has many workers, and a separate queue for any operation that changes the sheets (title changes, updating feeder answers in the meta sheets) with a single worker. I imagine sheet creation is the most important thing anyways.

