### PR TITLE
Remove voice chat link (currently useless), and stop calling Discord API to generate invite links

### DIFF
--- a/discord_lib/discord_chat_service.py
+++ b/discord_lib/discord_chat_service.py
@@ -112,5 +112,4 @@ class DiscordChatService(ChatService):
         return channel
 
     def create_channel_url(self, channel_id):
-        invite = self._client.channels_invites_create(channel_id, max_age=0)
-        return f"https://discord.gg/{invite.code}"
+        return f"https://discord.com/channels/{self._guild_id}/{channel_id}"

--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -77,10 +77,6 @@ const TABLE_COLUMNS = [
     Cell: ({ row, value }) =>
       row.original.chat_room ? (
         <>
-          <a href={row.original.chat_room.audio_channel_url} target="_blank">
-            Voice
-          </a>
-          <br />
           <a href={row.original.chat_room.text_channel_url} target="_blank">
             Text
           </a>


### PR DESCRIPTION
Stop generating invite links and use /guild_id/category_id instead. Also stop showing voice links which are useless.