### PR TITLE
Some fixes/safety for meta sheet updates

### DIFF
--- a/answers/views.py
+++ b/answers/views.py
@@ -101,10 +101,11 @@ class AnswerView(LoginRequiredMixin, View):
 
                 guess.set_status(status)
 
-            if puzzle_already_solved or status == Answer.CORRECT:
-                metas = guess.puzzle.metas.all()
-                for meta in metas:
-                    google_api_lib.task.update_meta_sheet_feeders(meta)
+            if google_api_lib.enabled():
+                if puzzle_already_solved or status == Answer.CORRECT:
+                    metas = guess.puzzle.metas.all()
+                    for meta in metas:
+                        google_api_lib.task.update_meta_sheet_feeders(meta)
         else:
             return JsonResponse(
                 {

--- a/google_api_lib/task.py
+++ b/google_api_lib/task.py
@@ -88,13 +88,8 @@ def update_meta_sheet_feeders(self, puzzle_id):
     latest feeder puzzle info
     """
     meta_puzzle = Puzzle.objects.get(pk=puzzle_id)
-    if not meta_puzzle.is_meta:
+    if not meta_puzzle.is_meta or not meta_puzzle.sheet:
         return
-
-    # TODO(erwa): Use work queue and separate process for running tasks.
-    # See https://github.com/cardinalitypuzzles/smallboard/pull/140
-    # for discussion. Need to use locking to prevent race conditions
-    # if there is more than one worker thread/process.
 
     logger.info(
         "Starting updating the meta sheet for '%s' " "with feeder puzzles" % meta_puzzle

--- a/puzzles/signals/handlers.py
+++ b/puzzles/signals/handlers.py
@@ -86,7 +86,8 @@ def update_meta_sheets_pre_delete(sender, instance, **kwargs):
         for meta in metas:
             google_api_lib.task.update_meta_sheet_feeders.delay(meta.id)
 
-    transaction.on_commit(update_metas)
+    if google_api_lib.enabled():
+        transaction.on_commit(update_metas)
 
 
 @receiver(m2m_changed, sender=Puzzle.metas.through)
@@ -98,4 +99,5 @@ def update_meta_sheets_m2m(sender, instance, action, reverse, model, pk_set, **k
                 meta = Puzzle.objects.get(pk=pk)
                 google_api_lib.task.update_meta_sheet_feeders.delay(meta.id)
 
-        transaction.on_commit(update_metas)
+        if google_api_lib.enabled():
+            transaction.on_commit(update_metas)


### PR DESCRIPTION
update_meta_sheet_feeders no longer checks if the google API is enabled,
so callers need to do it.

We also don't check if there's a sheeet url, so do that too.