### PR TITLE
fix answer filter regression

### DIFF
--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -46,6 +46,7 @@ const TABLE_COLUMNS = [
     Header: "Answer",
     accessor: (row) => row.guesses.map(({ text }) => text).join(" "),
     Cell: AnswerCell,
+    id: "answer",
   },
   {
     Header: "Status",

--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -19,8 +19,7 @@ function textFilterFn(rows, id, filterValue) {
   if (!words) {
     return rows;
   }
-
-  const keys = ["values.name", "values.tags", "values.status", "values.answer"];
+  const keys = ["values.name", "values.tags", "values.status", "values.Answer"];
   // Need to clone these results because this library is broken as shit
   return words
     .reduceRight((results, word) => matchSorter(results, word, { keys }), rows)

--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -19,7 +19,7 @@ function textFilterFn(rows, id, filterValue) {
   if (!words) {
     return rows;
   }
-  const keys = ["values.name", "values.tags", "values.status", "values.Answer"];
+  const keys = ["values.name", "values.tags", "values.status", "values.answer"];
   // Need to clone these results because this library is broken as shit
   return words
     .reduceRight((results, word) => matchSorter(results, word, { keys }), rows)


### PR DESCRIPTION
Add `.Answer` to the search field, understanding that `.answer` was removed during multi-answer support. (please confirm @rgossiaux @asdfryan)