### PR TITLE
Add logging config to settings.py

### DIFF
--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -268,3 +268,20 @@ CELERY_TASK_TRACK_STARTED = True
 CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://")
 CELERY_BROKER_TRANSPORT_OPTIONS = {"max_retries": 3}
 CELERY_REDIS_MAX_CONNECTIONS = 2
+
+# Logging configuration
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+        },
+    },
+}


### PR DESCRIPTION
For logging exception data when DEBUG=False (ie production). By default
they're swallowed without configuration.