### PR TITLE
Use sheet redirect endpoint on the frontend

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -100,6 +100,7 @@ class PuzzleSerializer(serializers.ModelSerializer):
     chat_room = ChatRoomSerializer(required=False)
     tags = PuzzleTagSerializer(required=False, many=True)
     guesses = serializers.SerializerMethodField()
+    sheet = serializers.SerializerMethodField()
     # Have to specify this explicitly for validate_url to run
     url = serializers.CharField()
     hunt_id = serializers.PrimaryKeyRelatedField(
@@ -113,6 +114,9 @@ class PuzzleSerializer(serializers.ModelSerializer):
 
         guesses = obj.guesses.filter(status=Answer.CORRECT)
         return AnswerSerializer(guesses, many=True).data
+
+    def get_sheet(self, obj):
+        return bool(obj.sheet)
 
     def validate_url(self, url):
         return url_normalize(url)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -100,7 +100,7 @@ class PuzzleSerializer(serializers.ModelSerializer):
     chat_room = ChatRoomSerializer(required=False)
     tags = PuzzleTagSerializer(required=False, many=True)
     guesses = serializers.SerializerMethodField()
-    sheet = serializers.SerializerMethodField()
+    has_sheet = serializers.SerializerMethodField()
     # Have to specify this explicitly for validate_url to run
     url = serializers.CharField()
     hunt_id = serializers.PrimaryKeyRelatedField(
@@ -115,7 +115,7 @@ class PuzzleSerializer(serializers.ModelSerializer):
         guesses = obj.guesses.filter(status=Answer.CORRECT)
         return AnswerSerializer(guesses, many=True).data
 
-    def get_sheet(self, obj):
+    def get_has_sheet(self, obj):
         return bool(obj.sheet)
 
     def validate_url(self, url):
@@ -157,7 +157,7 @@ class PuzzleSerializer(serializers.ModelSerializer):
             "hunt_id",
             "url",
             "notes",
-            "sheet",
+            "has_sheet",
             "chat_room",
             "status",
             "tags",
@@ -170,7 +170,7 @@ class PuzzleSerializer(serializers.ModelSerializer):
         read_only_fields = (
             "id",
             "hunt_id",
-            "sheet",
+            "has_sheet",
             "chat_room",
             "guesses",
             "tags",

--- a/api/tests.py
+++ b/api/tests.py
@@ -60,7 +60,7 @@ class ApiTests(SmallboardTestCase):
                 "hunt_id": self._hunt.pk,
                 "url": TEST_URL,
                 "notes": "",
-                "sheet": None,
+                "sheet": False,
                 "chat_room": None,
                 "status": "SOLVING",
                 "tags": [],

--- a/api/tests.py
+++ b/api/tests.py
@@ -60,7 +60,7 @@ class ApiTests(SmallboardTestCase):
                 "hunt_id": self._hunt.pk,
                 "url": TEST_URL,
                 "notes": "",
-                "sheet": False,
+                "has_sheet": False,
                 "chat_room": None,
                 "status": "SOLVING",
                 "tags": [],

--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -65,7 +65,7 @@ const TABLE_COLUMNS = [
   },
   {
     Header: "Sheet",
-    accessor: "sheet",
+    accessor: "has_sheet",
     Cell: ({ row, value }) =>
       value ? (
         <a href={`${SHEET_REDIRECT_BASE}/${row.original.id}`} target="_blank">

--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -25,6 +25,7 @@ import Dropdown from "react-bootstrap/Dropdown";
 import Modal from "react-bootstrap/Modal";
 import Alert from "react-bootstrap/Alert";
 import { SOLVE_STATE_FILTER_OPTIONS } from "./solveStateFilter";
+import { SHEET_REDIRECT_BASE } from "./constants";
 
 const MODAL_COMPONENTS = {
   DELETE_PUZZLE: DeletePuzzleModal,
@@ -67,7 +68,7 @@ const TABLE_COLUMNS = [
     accessor: "sheet",
     Cell: ({ row, value }) =>
       value ? (
-        <a href={value} target="_blank">
+        <a href={`${SHEET_REDIRECT_BASE}/${row.original.id}`} target="_blank">
           Sheet
         </a>
       ) : null,

--- a/hunts/src/constants.js
+++ b/hunts/src/constants.js
@@ -15,3 +15,5 @@ export const DEFAULT_TAGS = [
   { name: "SLOG", color: "secondary" },
   { name: "INTERACTIVE", color: "primary" },
 ];
+
+export const SHEET_REDIRECT_BASE = "/puzzles/s";


### PR DESCRIPTION
Makes /puzzles responses almost 25% shorter. Hard to say precisely how
it affects the response time (too variable) but it appears to be a nice
improvement as well which is what I would expect. The only downside is
that opening a sheet is now a little slower since we have to do the
redirect.