### PR TITLE
Lower CELERY_BROKER_POOL_LIMIT to two connections

### DIFF
--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -267,7 +267,8 @@ CELERY_TASK_TIME_LIMIT = 60
 CELERY_TASK_TRACK_STARTED = True
 CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://")
 CELERY_BROKER_TRANSPORT_OPTIONS = {"max_retries": 3}
-CELERY_REDIS_MAX_CONNECTIONS = 2
+CELERY_BROKER_POOL_LIMIT = 2
+CELERY_REDIS_MAX_CONNECTIONS = 2  # Only for sending results, not enqueueing tasks
 
 # Logging configuration
 LOGGING = {


### PR DESCRIPTION
This setting seems to be distinct from CELERY_REDIS_MAX_CONNECTIONS