### PR TITLE
Lower worker connection pool 2 => 1

### DIFF
--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -273,7 +273,7 @@ CELERY_TASK_TRACK_STARTED = True
 CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://")
 CELERY_BROKER_TRANSPORT_OPTIONS = {"max_retries": 3}
 CELERY_BROKER_POOL_LIMIT = 1
-CELERY_REDIS_MAX_CONNECTIONS = 2  # Only for sending results, not enqueueing tasks
+CELERY_REDIS_MAX_CONNECTIONS = 1  # Only for sending results, not enqueueing tasks
 
 # Logging configuration
 LOGGING = {

--- a/smallboard/settings.py
+++ b/smallboard/settings.py
@@ -272,7 +272,7 @@ CELERY_TASK_TIME_LIMIT = 60
 CELERY_TASK_TRACK_STARTED = True
 CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://")
 CELERY_BROKER_TRANSPORT_OPTIONS = {"max_retries": 3}
-CELERY_BROKER_POOL_LIMIT = 2
+CELERY_BROKER_POOL_LIMIT = 1
 CELERY_REDIS_MAX_CONNECTIONS = 2  # Only for sending results, not enqueueing tasks
 
 # Logging configuration


### PR DESCRIPTION
Looks like this is one connection pool per worker process (and multiple
worker processes run at once) so keeping this small. Can also try None
for no connection pool (new connection every time) if we have to.