### PR TITLE
Disable celery heartbeat, gossip, mingle

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 release: python manage.py migrate --noinput
 web: gunicorn smallboard.wsgi --log-file -
-worker: celery -A smallboard worker -l INFO
+worker: celery -A smallboard worker -l INFO --without-heartbeat --without-gossip --without-mingle
 bot: python manage.py rundiscordbot


### PR DESCRIPTION
Some suggestions online to disable these for keeping redis connection
counts down as they all add extra connections. Gossip is only used for
clock sync, mingle is only for some inter-worker sycnhronization
(especially for letting new workers know about unprocessed revoked
tasks--not something we need to worry about as our worker pool will be
constant and we won't be revoking tasks), heartbeat is useless as we
only have one redis node.