### PR TITLE
Fix bad expand/filter interaction

### DIFF
--- a/hunts/src/solveStateFilter.js
+++ b/hunts/src/solveStateFilter.js
@@ -42,13 +42,17 @@ export function filterSolvedPuzzlesfn(rows, id, filterValue) {
         });
       }
     });
-    return rows.filter((row) => !rowIdsToExclude.has(row.id));
+    return rows
+      .filter((row) => !rowIdsToExclude.has(row.id))
+      .map((row) => Object.assign({}, row));
   }
 
   if (filterValue === SOLVE_STATE_FILTER_OPTIONS.UNSOLVED_WITH_SOLVED_METAS) {
-    return rows.filter((row) => {
-      return isUnsolved(row) || hasUnsolvedDescendants(row);
-    });
+    return rows
+      .filter((row) => {
+        return isUnsolved(row) || hasUnsolvedDescendants(row);
+      })
+      .map((row) => Object.assign({}, row));
   }
 }
 


### PR DESCRIPTION
Fixes #341.

react-table does some buggy stuff modifying subRows, so making a copy in
your filter function is the easiest way to deal with it--had to do
something similar with useGlobalFilters for the search bar.