### PR TITLE
Discord bot: paging, chat links, tweaks

### DIFF
--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -99,7 +99,7 @@ async def send_puzzles(message, puzzles, title):
             chunk_lines = []
             chunk_length = 0
         if embed_length + line_length >= 6000:
-            message.channel.send(embed=embed)
+            await message.channel.send(embed=embed)
             embed = discord.Embed()
             embed_length = len(title)
         chunk_lines.append(line)

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -73,10 +73,10 @@ async def send_puzzles(message, puzzles, title):
     embed = discord.Embed(title=title)
     lines = []
     for p in puzzles:
-        title = ""
+        line_title = ""
         if p.is_solved():
-            title += f"[{p.answer}] "
-        title += p.name
+            line_title += f"[{p.answer}] "
+        line_title += p.name
 
         line = ""
         if p.url:
@@ -87,21 +87,19 @@ async def send_puzzles(message, puzzles, title):
             if p.chat_room.text_channel_url:
                 line += f"([chat]({p.chat_room.text_channel_url}))"
 
-        lines.append((title, line))
+        lines.append((line_title, line))
     print(f"lines: {lines}")
     lines.sort()
-    embed_length = len(title)
     field_count = 0
     for line in lines:
         line_length = sum([len(x) for x in line])
-        if (line_length + embed_length) >= 6000 or field_count >= 25:
+        if (line_length + len(embed)) >= 6000 or field_count >= 25:
             await message.channel.send(embed=embed)
             embed = discord.Embed(title=title)
             embed_length = len(title)
             field_count = 0
         embed.add_field(name=line[0], value=line[1])
         field_count += 1
-        embed_length += line_length
     await message.channel.send(embed=embed)
 
 

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -81,7 +81,7 @@ async def send_puzzles(message, puzzles, title):
             line += f" ([sheet](https://smallboard.app/puzzles/s/{p.id}))"
         if p.chat_room:
             if p.chat_room.text_channel_url:
-                line += f" ([chat])({p.chat_room.text_channel_url})"
+                line += f" ([chat]({p.chat_room.text_channel_url}))"
 
         lines.append(line)
     print(f"lines: {lines}")

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -88,12 +88,20 @@ async def send_puzzles(message, puzzles, title):
     lines.sort()
     chunk_lines = []
     chunk_length = 0
+    embed_length = len(title)
     for line in lines:
-        line_length = len(line)
-        if (chunk_length + line_length + len(chunk_lines)) >= 1024:
+        line_length = len(line) + 1  # Add in the newline
+        if (chunk_length + line_length) >= 1024 or (
+            chunk_length + line_length + embed_length
+        ) >= 6000:
             embed.add_field(name=title, value="\n".join(chunk_lines))
+            embed_length += chunk_length + len(title)
             chunk_lines = []
             chunk_length = 0
+        if embed_length + line_length >= 6000:
+            message.channel.send(embed=embed)
+            embed = discord.Embed()
+            embed_length = len(title)
         chunk_lines.append(line)
         chunk_length += line_length
     if chunk_lines:

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -70,42 +70,38 @@ async def send_puzzles_stuck(message):
 
 async def send_puzzles(message, puzzles, title):
     print(f"Sending puzzles {puzzles}")
-    embed = discord.Embed()
+    embed = discord.Embed(title=title)
     lines = []
     for p in puzzles:
-        line = "- "
+        title = ""
         if p.is_solved():
-            line += f"[{p.answer}] "
-        line += f"[{p.name}]({p.url})" if p.url else p.name
+            title += f"[{p.answer}] "
+        title += p.name
+
+        line = ""
+        if p.url:
+            line += f"[Puzzle]({p.url})"
         if p.sheet:
-            line += f" ([sheet](https://smallboard.app/puzzles/s/{p.id}))"
+            line += f"([sheet](https://smallboard.app/puzzles/s/{p.id}))"
         if p.chat_room:
             if p.chat_room.text_channel_url:
-                line += f" ([chat]({p.chat_room.text_channel_url}))"
+                line += f"([chat]({p.chat_room.text_channel_url}))"
 
-        lines.append(line)
+        lines.append((title, line))
     print(f"lines: {lines}")
     lines.sort()
-    chunk_lines = []
-    chunk_length = 0
     embed_length = len(title)
+    field_count = 0
     for line in lines:
-        line_length = len(line) + 1  # Add in the newline
-        if (chunk_length + line_length) >= 1024 or (
-            chunk_length + line_length + embed_length
-        ) >= 6000:
-            embed.add_field(name=title, value="\n".join(chunk_lines))
-            embed_length += chunk_length + len(title)
-            chunk_lines = []
-            chunk_length = 0
-        if embed_length + line_length >= 6000:
+        line_length = sum([len(x) for x in line])
+        if (line_length + embed_length) >= 6000 or field_count >= 25:
             await message.channel.send(embed=embed)
-            embed = discord.Embed()
+            embed = discord.Embed(title=title)
             embed_length = len(title)
-        chunk_lines.append(line)
-        chunk_length += line_length
-    if chunk_lines:
-        embed.add_field(name=title, value="\n".join(chunk_lines))
+            field_count = 0
+        embed.add_field(name=line[0], value=line[1])
+        field_count += 1
+        embed_length += line_length
     await message.channel.send(embed=embed)
 
 

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -80,7 +80,7 @@ async def send_puzzles(message, puzzles, title):
 
         line = ""
         if p.url:
-            line += f"[Puzzle]({p.url})"
+            line += f"[Puzzle]({p.url}) "
         if p.sheet:
             line += f"([sheet](https://smallboard.app/puzzles/s/{p.id}))"
         if p.chat_room:

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -98,7 +98,7 @@ async def send_puzzles(message, puzzles, title):
             embed = discord.Embed(title=title)
             embed_length = len(title)
             field_count = 0
-        embed.add_field(name=line[0], value=line[1], inline=False)
+        embed.add_field(name=line[0], value=line[1], inline=True)
         field_count += 1
     await message.channel.send(embed=embed)
 

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -98,7 +98,7 @@ async def send_puzzles(message, puzzles, title):
             embed = discord.Embed(title=title)
             embed_length = len(title)
             field_count = 0
-        embed.add_field(name=line[0], value=line[1])
+        embed.add_field(name=line[0], value=line[1], inline=False)
         field_count += 1
     await message.channel.send(embed=embed)
 

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -44,14 +44,16 @@ async def send_puzzles_unsolved(message):
         Puzzle.objects.filter(
             Q(hunt=settings.BOT_ACTIVE_HUNT),
             Q(status=Puzzle.SOLVING) | Q(status=Puzzle.PENDING),
-        )
+        ).select_related("chat_room")
     )
     await send_puzzles(message, puzzles, "Unsolved puzzles")
 
 
 async def send_puzzles_solved(message):
     puzzles = await sync_to_async(list)(
-        Puzzle.objects.filter(hunt=settings.BOT_ACTIVE_HUNT, status=Puzzle.SOLVED)
+        Puzzle.objects.filter(
+            hunt=settings.BOT_ACTIVE_HUNT, status=Puzzle.SOLVED
+        ).select_related("chat_room")
     )
     await send_puzzles(message, puzzles, "Solved puzzles")
 
@@ -61,7 +63,7 @@ async def send_puzzles_stuck(message):
         Puzzle.objects.filter(
             Q(hunt=settings.BOT_ACTIVE_HUNT),
             Q(status=Puzzle.STUCK) | Q(status=Puzzle.EXTRACTION),
-        )
+        ).select_related("chat_room")
     )
     await send_puzzles(message, puzzles, "Stuck puzzles")
 

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -76,9 +76,14 @@ async def send_puzzles(message, puzzles, title):
             line += f"[{p.answer}] "
         line += f"[{p.name}]({p.url})" if p.url else p.name
         if p.sheet:
-            line += f" ([sheet]({p.sheet}))"
+            line += f" ([sheet](https://smallboard.app/puzzles/s/{p.id}))"
+        if p.chat_room:
+            if p.chat_room.text_channel_url:
+                line += f" ([chat])({p.chat_room.text_channel_url})"
+
         lines.append(line)
     print(f"lines: {lines}")
+    lines.sort()
     chunk_lines = []
     chunk_length = 0
     for line in lines:

--- a/chat/management/commands/rundiscordbot.py
+++ b/chat/management/commands/rundiscordbot.py
@@ -90,7 +90,7 @@ async def send_puzzles(message, puzzles, title):
     chunk_length = 0
     for line in lines:
         line_length = len(line)
-        if (chunk_length + line_length) >= 1024:
+        if (chunk_length + line_length + len(chunk_lines)) >= 1024:
             embed.add_field(name=title, value="\n".join(chunk_lines))
             chunk_lines = []
             chunk_length = 0


### PR DESCRIPTION
* Use shortened sheet redirect URLs
* Add links to chat channels
* Use one puzzle per field instead of grouping multiple puzzles inside the same field
* Add paging across multiple messages

You can see the latest on #bot-spam. I've also turned off manual deploys for cardi P and it's deployed to the latest on this branch manually for now so you can interact on discord yourself.