### PR TITLE
Make status editable even after marked as SOLVED

### DIFF
--- a/hunts/src/StatusCell.js
+++ b/hunts/src/StatusCell.js
@@ -27,7 +27,7 @@ export default function StatusCell({ row, value }) {
           );
         }}
       >
-        {statuses_to_display.map(status_to_display => (
+        {statuses_to_display.map((status_to_display) => (
           <Dropdown.Item eventKey={status_to_display} key={status_to_display}>
             {status_to_display}
           </Dropdown.Item>

--- a/hunts/src/StatusCell.js
+++ b/hunts/src/StatusCell.js
@@ -7,8 +7,12 @@ import { updatePuzzle } from "./puzzlesSlice";
 export default function StatusCell({ row, value }) {
   const { id: huntId } = useSelector((state) => state.hunt);
   const dispatch = useDispatch();
-  if (["SOLVING", "STUCK", "EXTRACTION"].includes(value)) {
-    return (
+  var statuses_to_display = ["SOLVING", "STUCK", "EXTRACTION"];
+  if (value == "SOLVED") {
+    statuses_to_display.push("SOLVED");
+  }
+  return (
+    <>
       <DropdownButton
         id={`status-dropdown-${row.id}`}
         title={value}
@@ -23,12 +27,12 @@ export default function StatusCell({ row, value }) {
           );
         }}
       >
-        <Dropdown.Item eventKey="SOLVING">SOLVING</Dropdown.Item>
-        <Dropdown.Item eventKey="STUCK">STUCK</Dropdown.Item>
-        <Dropdown.Item eventKey="EXTRACTION">EXTRACTION</Dropdown.Item>
+        {statuses_to_display.map(status_to_display => (
+          <Dropdown.Item eventKey={status_to_display} key={status_to_display}>
+            {status_to_display}
+          </Dropdown.Item>
+        ))}
       </DropdownButton>
-    );
-  } else {
-    return value;
-  }
+    </>
+  );
 }

--- a/hunts/src/StatusCell.js
+++ b/hunts/src/StatusCell.js
@@ -7,8 +7,8 @@ import { updatePuzzle } from "./puzzlesSlice";
 export default function StatusCell({ row, value }) {
   const { id: huntId } = useSelector((state) => state.hunt);
   const dispatch = useDispatch();
-  var statuses_to_display = ["SOLVING", "STUCK", "EXTRACTION"];
-  if (value == "SOLVED") {
+  const statuses_to_display = ["SOLVING", "STUCK", "EXTRACTION"];
+  if (value === "SOLVED") {
     statuses_to_display.push("SOLVED");
   }
   return (


### PR DESCRIPTION
`SOLVED` is only listed as an option for solved puzzles. (i.e. it is only possible to "SOLVE" a puzzle by adding an answer)

![Screen Shot 2021-01-14 at 12 26 33 PM](https://user-images.githubusercontent.com/1498449/104645351-c910bb00-5663-11eb-8892-5c3de3f3efa2.png)
![Screen Shot 2021-01-14 at 12 26 43 PM](https://user-images.githubusercontent.com/1498449/104645356-ca41e800-5663-11eb-9d33-aef04f0c42b6.png)
