### PR TITLE
Add CRYPTICS to list of default tags

### DIFF
--- a/hunts/src/constants.js
+++ b/hunts/src/constants.js
@@ -10,6 +10,7 @@ export const DEFAULT_TAGS = [
   { name: "LOW PRIORITY", color: "warning" },
   { name: "BACKSOLVED", color: "success" },
   { name: "WORD", color: "light" },
+  { name: "CRYPTICS", color: "light" },
   { name: "LOGIC", color: "light" },
   { name: "MEDIA MANIPULATION", color: "light" },
   { name: "PROGRAMMING", color: "light" },


### PR DESCRIPTION
To make it match the "cryptics" role on Discord