### PR TITLE
Chart accounts for puzzles made/solved before start time

### DIFF
--- a/hunts/chart_utils.py
+++ b/hunts/chart_utils.py
@@ -57,9 +57,12 @@ def get_chart_data(hunt, unlocks=False):
             break
         labels.append(puzzle.name)
         if unlocks:
-            times.append(puzzle.created_on.isoformat())
+            time_data = puzzle.created_on
         else:
-            times.append(puzzle._solved_time.isoformat())
+            time_data = puzzle._solved_time
+        if time_data < chart_start_time:
+            time_data = chart_start_time
+        times.append(time_data.isoformat())
         counts.append(i + 1)
         if not unlocks:
             is_meta.append(puzzle.is_meta)

--- a/hunts/tests.py
+++ b/hunts/tests.py
@@ -218,21 +218,6 @@ class TestHunt(TestCase):
             times, [hunt_past.start_time.isoformat(), hunt_past.end_time.isoformat()]
         )
 
-    def test_chart_utils_puzzle_before(self):
-        # test behavior when puzzle created before start time
-        unsolved_name = "puzzle_unsolved"
-
-        hunt = self.create_hunt(
-            "hunt",
-            start=timezone.now() + timedelta(days=100),
-            end=timezone.now() + timedelta(days=200),
-        )
-        puzzle_unsolved = self.create_puzzle(unsolved_name, hunt, False)
-        labels, times, counts = get_chart_data(hunt, unlocks=True)
-        self.assertEqual(
-            times[:2], [hunt.start_time.isoformat(), hunt.start_time.isoformat()]
-        )
-
 
 class HuntFormTests(TestCase):
     def setUp(self):

--- a/hunts/tests.py
+++ b/hunts/tests.py
@@ -218,6 +218,21 @@ class TestHunt(TestCase):
             times, [hunt_past.start_time.isoformat(), hunt_past.end_time.isoformat()]
         )
 
+    def test_chart_utils_puzzle_before(self):
+        # test behavior when puzzle created before start time
+        unsolved_name = "puzzle_unsolved"
+
+        hunt = self.create_hunt(
+            "hunt",
+            start=timezone.now() + timedelta(days=100),
+            end=timezone.now() + timedelta(days=200),
+        )
+        puzzle_unsolved = self.create_puzzle(unsolved_name, hunt, False)
+        labels, times, counts = get_chart_data(hunt, unlocks=True)
+        self.assertEqual(
+            times[:2], [hunt.start_time.isoformat(), hunt.start_time.isoformat()]
+        )
+
 
 class HuntFormTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
time datapoint is set to chart_start_time if made/solved before chart_start_time