### PR TITLE
Fixed broken https://console.developers.google.com/ link

### DIFF
--- a/new-hunt-setup.md
+++ b/new-hunt-setup.md
@@ -4,7 +4,7 @@ Currently, smallboard is not multi-tenant (see [#191](https://github.com/cardina
 
 ### Prerequisites
 
-This guide assumes you have already created the following at [https://console.developers.google.com/]():
+This guide assumes you have already created the following at https://console.developers.google.com/:
 
 * a Google Cloud project
 * a Google API service account (go to APIs & Services > Credentials) under that project


### PR DESCRIPTION
Markdown is tricky. Apparently for straight-up URLs, you don't need to surround with brackets or add parentheses after the brackets.